### PR TITLE
Collapse layer selector unless hovered by mouse pointer

### DIFF
--- a/frontend/pngs.d.ts
+++ b/frontend/pngs.d.ts
@@ -1,0 +1,1 @@
+declare module '*.png'

--- a/frontend/src/ForecastLayer.ts
+++ b/frontend/src/ForecastLayer.ts
@@ -11,6 +11,7 @@ import { boundaryDepthColorScale, BoundaryLayerDepth } from './layers/BoundaryLa
 import { Wind, windColor } from './layers/Wind';
 import { None } from './layers/None';
 import { drawWindArrow } from './shapes';
+import layersImg from './images/layers.png';
 
 class Renderer {
 
@@ -124,18 +125,43 @@ export class ForecastLayer {
     const cloudCoverEl = this.setupRendererBtn(cloudCoverRenderer);
     const mixedEl = this.setupRendererBtn(mixedRenderer);
 
-    const rootElement = el(
+    const selectEl = el(
       'div',
-      {
-        style: { position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)', zIndex: 1000 }
-      },
+      { style: { display: 'none' } },
       noneEl,
       thqEl,
       boundaryLayerHeightEl,
       windEl,
       cloudCoverEl,
       mixedEl
-    )
+    );
+
+    const layersBtn = el(
+      'div',
+      { style: {  } },
+      el(
+        'a',
+        { style: { width: '44px', height: '44px', backgroundImage: `url('${layersImg}')`, display: 'block', backgroundPosition: '50% 50%', backgroundRepeat: 'no-repeat' } }
+      )
+    );
+
+    const rootElement = el(
+      'div',
+      { style: { position: 'absolute', right: '3px', bottom: '100px', zIndex: 1000 /* arbitrary value to be just above the zoom control */, background: 'white', border: '1px solid rgba(0, 0, 0, 0.2)', borderRadius: '5px' } },
+      layersBtn,
+      selectEl
+    );
+
+    rootElement.onmouseenter = _ => {
+      selectEl.style.display = 'unset';
+      layersBtn.style.display = 'none';
+    };
+
+    rootElement.onmouseleave = _ => {
+      selectEl.style.display = 'none';
+      layersBtn.style.display = 'unset';
+    };
+
     L.DomEvent.disableClickPropagation(rootElement);
     L.DomEvent.disableScrollPropagation(rootElement);
     mount(containerElement, rootElement);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,5 +5,6 @@
     "module": "CommonJS",
     "strict": true,
     "inlineSourceMap": true
-  }
+  },
+  "include": ["./pngs.d.ts"]
 }


### PR DESCRIPTION
Instead of always showing the list of layers that can be displayed on the map, we show a layers button by default, and we expand it when the mouse hovers on it.

![Screenshot from 2020-12-03 22-23-55](https://user-images.githubusercontent.com/332812/101090287-b1e7a380-35b6-11eb-9d71-dfbf28fcdf66.png)

This avoids having the list of layers above the meteogram on mobile devices.