### PR TITLE
Improve XC flying potential index

### DIFF
--- a/frontend/src/diagrams/Meteogram.tsx
+++ b/frontend/src/diagrams/Meteogram.tsx
@@ -352,7 +352,7 @@ export const airDiagramHeightAboveGroundLevel = 3500; // m
   if (leftKeyCtx !== null) {
     // Thq
     const thqDiagram = new Diagram([0, thqDiagramTop], thqDiagramHeight, leftKeyCtx);
-    thqDiagram.text('ThQ', [keyWidth / 2, 8], 'black', 'center', 'middle');
+    thqDiagram.text('XC?', [keyWidth / 2, 8], 'black', 'center', 'middle');
 
     // High air diagram
     const highAirDiagram = new Diagram([0, highAirDiagramTop], highAirDiagramHeight, leftKeyCtx);


### PR DESCRIPTION
Previously, the computation was too penalized when there was a little bit of clouds.
The new computation uses a logistic function, just like it was done in soaringmeteo v1. I believe the new results are a bit better, but we experience will tell us if we need to tweak again the formula manually...

Before:

![Screenshot from 2022-04-16 18-35-24](https://user-images.githubusercontent.com/332812/163683937-613ccb40-4bfc-4819-9a41-63bf9d1e9aa3.png)

After:

![Screenshot from 2022-04-16 18-36-05](https://user-images.githubusercontent.com/332812/163683945-d251ac75-bcc6-490f-a54c-469d4ac7535b.png)

Before:

![Screenshot from 2022-04-16 18-39-28](https://user-images.githubusercontent.com/332812/163683954-cb9adcf4-d2b9-4aad-8efe-278bc5215fe5.png)

After:

![Screenshot from 2022-04-16 18-37-20](https://user-images.githubusercontent.com/332812/163683964-74e0b16c-f53e-4209-b487-510f5dc10626.png)

For reference, the “mixed” layer shows this:

![Screenshot from 2022-04-16 18-37-33](https://user-images.githubusercontent.com/332812/163683978-ca88e5f6-896e-4a1a-9dd1-1022d24cf662.png)
