### PR TITLE
Cumulus mediocris should not be opaque

### DIFF
--- a/frontend/src/layers/CumuliDepth.ts
+++ b/frontend/src/layers/CumuliDepth.ts
@@ -5,7 +5,7 @@ import * as L from 'leaflet';
 export const colorScale = new ColorScale([
   [0,    new Color(0xff, 0xff, 0xff, 0)],
   [50,   new Color(0xff, 0xff, 0xff, 0.2)],
-  [400,  new Color(0xff, 0xff, 0xff, 1)],
+  [400,  new Color(0xff, 0xff, 0xff, 0.5)],
   [800,  new Color(0xff, 0xff, 0x00, 0.5)],
   [1500, new Color(0xff, 0x00, 0x00, 0.5)]
 ]);


### PR DESCRIPTION
As noticed in https://github.com/soaringmeteo/soaringmeteo/pull/32#issuecomment-1100677508 cumulus mediocris were shown completely opaque.

This PR fixes that.

![Screenshot from 2022-04-16 19-00-58](https://user-images.githubusercontent.com/332812/163684438-9421c40d-b3fd-4a51-82f3-b47fc0801067.png)

Regarding the second part of the comment:

> Would grey not be better than red for high-density clouds?

I chose to use red for highly developed clouds (congestus or cumulonimbus) because they might be dangerous for soaring. But I am open to discussion :)