### PR TITLE
Base XC flying potential on thermal velocity instead of cloud cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The “XC Flying Potentials” overlay shows the potential of the area for XC fl
 
 ![](images/controls-layers-thq.png)
 
-This single indicator takes into account the boundary layer depth, the average wind speed within the boundary layer, and the total cloud cover. It uses the following color scale (100% means a high chance of XC flying):
+This single indicator takes into account the boundary layer depth, the thermals velocity, and the average wind speed within the boundary layer. It uses the following color scale (100% means a high chance of XC flying):
 
 ![](images/key-thq.png)
 

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
@@ -1,7 +1,6 @@
 package org.soaringmeteo.gfs.out
 
 import io.circe.{Encoder, Json}
-import org.soaringmeteo.Temperatures.dewPoint
 import org.soaringmeteo.gfs.in
 import org.soaringmeteo.{Point, Wind}
 import squants.energy.SpecificEnergy

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/LocationForecasts.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/LocationForecasts.scala
@@ -5,11 +5,12 @@ import java.time.{LocalDate, OffsetDateTime}
 import io.circe.{Encoder, Json}
 import org.soaringmeteo.gfs.Settings
 import org.soaringmeteo.{Point, Wind}
+import squants.Velocity
 import squants.energy.SpecificEnergy
 import squants.motion.Pressure
 import squants.radio.Irradiance
 import squants.space.{Length, Meters}
-import squants.thermal.{Celsius, Temperature}
+import squants.thermal.Temperature
 
 import java.math.MathContext
 import scala.collection.immutable.SortedMap
@@ -36,7 +37,7 @@ case class DetailedForecast(
   time: OffsetDateTime,
   boundaryLayerHeight: Length,
   boundaryLayerWind: Wind,
-  totalCloudCover: Int, // Between 0 and 100
+  thermalVelocity: Velocity,
   convectiveCloudCover: Int, // Between 0 and 100
   convectiveClouds: Option[ConvectiveClouds],
   airDataByAltitude: SortedMap[Length, AirData],
@@ -65,7 +66,7 @@ object LocationForecasts {
             forecast.time,
             forecast.boundaryLayerDepth,
             forecast.boundaryLayerWind,
-            forecast.totalCloudCover,
+            forecast.thermalVelocity,
             forecast.convectiveCloudCover,
             forecast.convectiveClouds,
             forecast.airDataByAltitude,
@@ -208,7 +209,7 @@ object LocationForecasts {
                       "u" -> Json.fromInt(forecast.boundaryLayerWind.u.toKilometersPerHour.round.toInt),
                       "v" -> Json.fromInt(forecast.boundaryLayerWind.v.toKilometersPerHour.round.toInt)
                     ),
-                    "c" -> Json.fromInt(forecast.totalCloudCover),
+                    "v" -> Json.fromInt((forecast.thermalVelocity.toMetersPerSecond * 10).round.toInt), // dm/s (to avoid floating point values)
                     "p" -> Json.arr(forecast.airDataByAltitude.map { case (elevation, aboveGround) =>
                       Json.obj(
                         "h" -> Json.fromInt(elevation.toMeters.round.toInt),

--- a/frontend/src/data/Forecast.ts
+++ b/frontend/src/data/Forecast.ts
@@ -109,7 +109,7 @@ export class DayForecasts {
 
 export class DetailedForecast {
   readonly time: Date;
-  readonly totalCloudCover: number; // %
+  readonly thermalVelocity: number; // m/s
   readonly boundaryLayer: DetailedBoundaryLayer;
   readonly surface: DetailedSurface;
   readonly rain: DetailedRain;
@@ -119,7 +119,7 @@ export class DetailedForecast {
 
   constructor(data: DetailedForecastData, elevation: number) {
     this.time = new Date(data.t);
-    this.totalCloudCover = data.c / 100;
+    this.thermalVelocity = data.v / 10;
     this.boundaryLayer = {
       height: data.bl.h,
       wind: {
@@ -214,8 +214,7 @@ export type DetailedForecastData = {
     u: number,
     v: number,
   }
-  // Total cloud cover
-  c: number,
+  v: number, // Thermal velocity
   // Above ground variables
   p: Array<{
     h: number, // altitude

--- a/frontend/src/diagrams/Meteogram.tsx
+++ b/frontend/src/diagrams/Meteogram.tsx
@@ -94,10 +94,10 @@ export const airDiagramHeightAboveGroundLevel = 3500; // m
 
     columns((forecast, columnStart, columnEnd) => {
       const thq = thqValue(
+        forecast.thermalVelocity,
         forecast.boundaryLayer.height,
         forecast.boundaryLayer.wind.u,
-        forecast.boundaryLayer.wind.v,
-        forecast.totalCloudCover
+        forecast.boundaryLayer.wind.v
       )
       thqDiagram.fillRect(
         [columnStart, 0],


### PR DESCRIPTION
We need sun to get thermals. Therefore, the XC flying potential indicator was based on the cloud cover. However, we experienced that high cloud cover was degrading the value of the indicator too much.

We propose to base the XC flying potential on the thermal velocity instead of the cloud cover. The thermal velocity is computed from the boundary layer height and the heat rate, so in a sense it also contains the information about the sunshine.

Before:

![Screenshot from 2022-04-24 20-34-45](https://user-images.githubusercontent.com/332812/164991400-39f6fc16-32ab-45c7-ad8e-f7072cc878e4.png)

After:

![Screenshot from 2022-04-24 20-35-06](https://user-images.githubusercontent.com/332812/164991410-a676fd11-1de9-4db4-aaae-9705db38d9ab.png)

Note the difference around Annecy. This is because GFS tells it will be cloudy:

![Screenshot from 2022-04-24 20-37-29](https://user-images.githubusercontent.com/332812/164991434-22403033-f6af-430c-a501-834fbae66606.png)