### PR TITLE
Use shades of green to indicate thermals velocity in meteograms

### DIFF
--- a/frontend/src/diagrams/Diagram.ts
+++ b/frontend/src/diagrams/Diagram.ts
@@ -1,3 +1,4 @@
+import { Color, ColorScale } from "../ColorScale";
 import { cloudPattern } from "../shapes";
 
 type Point = [/* x */ number, /* y */ number]
@@ -155,7 +156,11 @@ export const temperaturesRange =
   }
 
 export const skyStyle = '#85c1e9';
-export const boundaryLayerStyle = 'mediumspringgreen';
+const thermalsVelocityColorScale = new ColorScale([
+  [0, new Color(173, 255, 47, 1)],
+  [3, new Color(0, 254, 154, 1)]
+]);
+export const boundaryLayerStyle = (thermalsVelocity: number): string => thermalsVelocityColorScale.interpolate(thermalsVelocity).css();
 
 export const meteogramColumnWidth = 33;
 

--- a/frontend/src/diagrams/Meteogram.ts
+++ b/frontend/src/diagrams/Meteogram.ts
@@ -158,7 +158,7 @@ const airDiagramHeightAboveGroundLevel = 3500; // m
       airDiagram.fillRect(
         [columnStart, 0],
         [columnEnd,   boundaryLayerHeight],
-        boundaryLayerStyle
+        boundaryLayerStyle(forecast.thermalVelocity)
       );
       // Blue sky
       airDiagram.fillRect(

--- a/frontend/src/diagrams/Sounding.tsx
+++ b/frontend/src/diagrams/Sounding.tsx
@@ -189,7 +189,7 @@ const drawSounding = (
   diagram.fillRect(
     [0, elevationScale.apply(elevation)],
     [width, elevationScale.apply(elevation + forecast.boundaryLayer.height)],
-    boundaryLayerStyle
+    boundaryLayerStyle(forecast.thermalVelocity)
   );
   diagram.fillRect(
     [0, elevationScale.apply(elevation + forecast.boundaryLayer.height)],


### PR DESCRIPTION
The idea is to indicate the velocity of the thermals with shades of green in meteograms.

For instance, here we can see that thermals of the morning should be stronger than the thermals of the afternoon, despite the boundary layer depth is similar:

![Screenshot from 2022-05-23 20-34-44](https://user-images.githubusercontent.com/332812/169888904-4b2682ef-1162-4574-8b35-cb039630b604.png)

Full example of meteogram:

![meteogram](https://user-images.githubusercontent.com/332812/169889095-0baec999-85ae-4bf5-8a64-c155bfa2927e.png)
