### PR TITLE
Don’t download GRIB files for old-soarGFS anymore

### DIFF
--- a/backend/src/main/scala/org/soaringmeteo/gfs/DownloadAndRead.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/DownloadAndRead.scala
@@ -39,9 +39,6 @@ object DownloadAndRead {
     reusePreviousGribFiles: Boolean
   ): out.ForecastsByHour = {
 
-    if (!reusePreviousGribFiles) {
-      os.remove.all(gribsDir)
-    }
     os.makeDir.all(gribsDir)
 
     logger.info("Downloading forecast data")
@@ -103,10 +100,6 @@ object DownloadAndRead {
           } yield (areaAndHour.hourOffset, forecasts)
         }
         .map { forecastsByHour =>
-          // TEMP Simulate old soargfs script for downloading data
-          // We can safely remove this line after we drop support for old soargfs
-          writeFilesForOldSoargfs(gribsDir)
-
           out.Forecast(
             forecastsByHour
               // Merge together all the forecasts from the different areas
@@ -117,12 +110,6 @@ object DownloadAndRead {
     }
 
     Await.result(eventualForecast, 8.hours)
-  }
-
-  private def writeFilesForOldSoargfs(gribsDir: os.Path): Unit = {
-    os.write.over(gribsDir / "aDone.txt", "")
-    os.write.over(gribsDir / "bDone.txt", "")
-    os.write.over(gribsDir / "cDone.txt", "")
   }
 
 }

--- a/backend/src/main/scala/org/soaringmeteo/gfs/Main.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/Main.scala
@@ -52,13 +52,14 @@ object Soaringmeteo {
             .getOrElse(sys.error(s"${point} is not in the downloaded GFS areas"))
         }
     val gfsRun = in.ForecastRun.findLatest(maybeGfsRunInitTime)
+    if (!reusePreviousGribFiles) {
+      logger.info("Removing old GRIB files")
+      os.remove.all(gribsDir)
+    }
     val forecastGribsDir = gfsRun.storagePath(gribsDir)
     val forecastsByHour = DownloadAndRead(forecastGribsDir, gfsRun, locationsByArea, reusePreviousGribFiles)
     JsonWriter.writeJsons(jsonDir, gfsRun, forecastsByHour, locationsByArea.values.flatten)
     logger.info("Done")
-    // Let’s keep the grib files because they are also used by the old soargfs
-    // We should uncomment this line after we drop support for old soargfs
-    // os.remove.all(forecastGribsDir)
   }.recover {
     case NonFatal(error) => logger.error("Failed to run soaringmeteo", error)
   }.get

--- a/backend/src/main/scala/org/soaringmeteo/gfs/in/ForecastRun.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/in/ForecastRun.scala
@@ -20,13 +20,11 @@ case class ForecastRun(
   /**
    * Name of the grib file we save on disk.
    *
-   * Currently, we use the same file name as the old soargfs, for compatibility.
-   *
    * @param areaAndHour Downloaded area, and number of hours since
    *                    initialization time
    */
   def fileName(areaAndHour: AreaAndHour): String =
-    f"GFS${areaAndHour.area.id}-initDate${initDateString}-initTime${initTimeString}-forecastTime${areaAndHour.hourOffset}%03d.grib2"
+    f"GFS${areaAndHour.area.id}-forecastTime${areaAndHour.hourOffset}%03d.grib2"
 
   /**
    * @param base Base path of the directory containing the grib files.


### PR DESCRIPTION
The implementation was motivated by the desire to download the GFS data once (several GB in total) and use it for both soarV2 and soarGFS. However, it didn’t work in practice because the GRIB files downloaded here are significantly larger than the ones downloaded by old soarGFS, and then old soarGFS takes too long time to analyze them and eventually fails.

In this commit, we don’t try to download the GRIB files anymore in way that they can be reused by old soarGFS. The consequence is that both soarV2 and old soarGFS will download data from the NOAA servers, so we need to be careful to not do it at the same time to avoid hitting the rate limit (120 hits/min).