### PR TITLE
Add a menu with links to the other parts of the website

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { Forecast } from './data/Forecast';
 import * as L from 'leaflet';
 import markerImg from './images/marker-icon.png';
 import { StateProvider, useState } from './State';
+import { Burger } from './Burger';
 
 export const start = (containerElement: HTMLElement): void => {
 
@@ -22,10 +23,7 @@ export const start = (containerElement: HTMLElement): void => {
 
   const App = (props: {
     forecastMetadatas: Array<ForecastMetadata>
-    forecastMetadata: ForecastMetadata
     morningOffset: number
-    hourOffset: number
-    currentForecast: Forecast 
   }): JSX.Element => {
 
     const [state, { clearLocationForecasts }] = useState();
@@ -80,6 +78,11 @@ export const start = (containerElement: HTMLElement): void => {
     // back to these components.
     // ForecastLayer displays the configuration button and manages the canvas overlay.
     return <>
+      <span style={{
+        position: 'absolute', top: 0, left: 0, 'z-index': 1200
+      }}>
+        <Burger />
+      </span>
       <PeriodSelectors morningOffset={props.morningOffset} />
       <ForecastLayer
         forecastMetadatas={props.forecastMetadatas}

--- a/frontend/src/Burger.tsx
+++ b/frontend/src/Burger.tsx
@@ -23,7 +23,8 @@ export const Burger = (): JSX.Element => {
         padding: '0.3em',
         border: 'thin solid darkGray',
         'box-sizing': 'border-box',
-        'background-color': 'white',
+        'background-color': '#009688',
+        color: '#fff',
         'text-align': 'center',
         'font-weight': 'bold',
         'font-size': '1.5em',
@@ -38,7 +39,7 @@ export const Burger = (): JSX.Element => {
     'font-size': '15px',
     'line-height': '1.5',
     'font-family': 'sans-serif',
-    'color': 'black'
+    'color': '#fff'
   };
 
   const entries = [
@@ -54,7 +55,8 @@ export const Burger = (): JSX.Element => {
   const options =
     <div
       style={{
-        'background-color': 'white',
+        'background-color': '#009688',
+        color: '#fff',
         'box-shadow': 'rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 3px 1px -2px, rgba(0, 0, 0, 0.2) 0px 1px 5px 0px',
         'border-radius': '0 0 4px 0'
       }}

--- a/frontend/src/Burger.tsx
+++ b/frontend/src/Burger.tsx
@@ -1,0 +1,76 @@
+import * as L from "leaflet";
+import { createSignal, JSX, Show } from "solid-js";
+import { marginTop as periodSelectorHeight } from "./PeriodSelector";
+import { useState } from './State';
+
+/**
+ * Burger menu with links to the other parts of the website.
+ * 
+ * The menu is hidden when a detailed view (meteogram or sounding)
+ * is displayed.
+ */
+export const Burger = (): JSX.Element => {
+
+  const [state] = useState();
+  const [expanded, setExpanded] = createSignal(false);
+
+  const menu =
+    <div
+      style={{
+        width: `${periodSelectorHeight}px`,
+        height: `${periodSelectorHeight}px`,
+        cursor: 'pointer',
+        padding: '0.3em',
+        border: 'thin solid darkGray',
+        'box-sizing': 'border-box',
+        'background-color': 'white',
+        'text-align': 'center',
+        'font-weight': 'bold',
+        'font-size': '1.5em',
+        'box-shadow': 'rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 3px 1px -2px, rgba(0, 0, 0, 0.2) 0px 1px 5px 0px',
+      }}
+      onClick={() => { setExpanded(!expanded()); }}
+    >☰</div>;
+  L.DomEvent.disableClickPropagation(menu);
+
+  const optionStyle = {
+    padding: '8px 16px',
+    'font-size': '15px',
+    'line-height': '1.5',
+    'font-family': 'sans-serif',
+    'color': 'black'
+  };
+
+  const entries = [
+    ['ⓘ Help',              'https://github.com/soaringmeteo/soaringmeteo/blob/main/README.md#usage'],
+    ['⌂ Soaringmeteo',       'https://soaringmeteo.org/'],
+    ['soarGFS',              'https://soaringmeteo.org/GFSw/googleMap.html'],
+    ['soarWRF',              'https://soaringmeteo.org/soarWRF'],
+    ['soarV2',               'https://soarwrf1.soaringmeteo.org/v2'],
+    ['Documents',            'https://soaringmeteo.org/docs.html'],
+    ['Support Soaringmeteo', 'https://soaringmeteo.org/don.html']
+  ]
+
+  const options =
+    <div
+      style={{
+        'background-color': 'white',
+        'box-shadow': 'rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 3px 1px -2px, rgba(0, 0, 0, 0.2) 0px 1px 5px 0px',
+        'border-radius': '0 0 4px 0'
+      }}
+    >
+      {
+        entries.map(([label, href]) => {
+          return <a href={href} style={{'text-decoration': 'none'}}><div style={optionStyle}>{label}</div></a>
+        })
+      }
+    </div>;
+  L.DomEvent.disableClickPropagation(options);
+
+  return <Show when={ state.locationForecasts === undefined }>
+    {menu}
+    <Show when={expanded()}>
+      {options}
+    </Show>
+  </Show>
+};

--- a/frontend/src/PeriodSelector.tsx
+++ b/frontend/src/PeriodSelector.tsx
@@ -8,7 +8,7 @@ import { meteogramColumnWidth } from './diagrams/Diagram';
 import { useState } from './State';
 
 const marginLeft = keyWidth;
-const marginTop = 35; // Day height + hour height + 2 (wtf)
+export const marginTop = 35; // Day height + hour height + 2 (wtf)
 
 const hover = (htmlEl: HTMLElement): HTMLElement => {
   let oldValue: string = 'inherit';


### PR DESCRIPTION
![desktop](https://user-images.githubusercontent.com/332812/192153542-26b9bb64-1cf9-4f6f-ac3b-d6903e8e6864.gif)

![mobile](https://user-images.githubusercontent.com/332812/192153551-cf2c2598-c611-448b-9ae4-faff1397d5a9.gif)

---

I first tried to reuse the same green navigation bar as on https://soaringmeteo.org, but I found that it was eating too much space:

![Screen Shot 2022-09-25 at 09 40 38](https://user-images.githubusercontent.com/332812/192153608-af2cfd7e-dd90-484e-94c2-7a4be1f76eaf.png)

So, ultimately I decided to only add a “burger button” on the top left corner, as shown in the first screenshots.