### PR TITLE
Increase precision of meteograms and soundings

### DIFF
--- a/backend/src/main/scala/org/soaringmeteo/gfs/in/Forecast.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/in/Forecast.scala
@@ -69,7 +69,7 @@ object Forecast {
   private val logger = LoggerFactory.getLogger(classOf[Forecast])
 
   val pressureLevels: Seq[motion.Pressure] =
-    Seq(20000, 30000, 40000, 45000, 50000, 55000, 60000, 65000, 70000, 75000, 80000, 85000, 90000, 95000)
+    Seq(20000, 30000, 40000, 45000, 50000, 55000, 60000, 65000, 70000, 75000, 80000, 85000, 90000, 92500, 95000, 97500, 100000)
       .map(Pascals(_))
 
   /**

--- a/backend/src/main/scala/org/soaringmeteo/gfs/in/GfsGrib.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/in/GfsGrib.scala
@@ -32,7 +32,10 @@ object GfsGrib {
     "lev_800_mb",
     "lev_850_mb",
     "lev_900_mb",
+    "lev_925_mb",
     "lev_950_mb",
+    "lev_975_mb",
+    "lev_1000_mb",
     "lev_convective_cloud_layer",
     "lev_entire_atmosphere",
     "lev_high_cloud_layer", // Used only by legacy soarGFS

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
@@ -54,18 +54,21 @@ case class AirData(
 )
 
 object AirData {
-  def apply(atPressure: Map[Pressure, in.IsobaricVariables]): SortedMap[Length, AirData] =
-    atPressure.view.map { case (_, variables) =>
-      val height = variables.geopotentialHeight
-      val aboveGround =
-        AirData(
-          variables.wind,
-          variables.temperature,
-          variables.dewPoint,
-          variables.cloudCover
-        )
-      height -> aboveGround
-    }.to(SortedMap)
+  def apply(atPressure: Map[Pressure, in.IsobaricVariables], groundLevel: Length): SortedMap[Length, AirData] =
+    atPressure.values
+      .view
+      .filter(_.geopotentialHeight >= groundLevel)
+      .map { variables =>
+        val height = variables.geopotentialHeight
+        val aboveGround =
+          AirData(
+            variables.wind,
+            variables.temperature,
+            variables.dewPoint,
+            variables.cloudCover
+          )
+        height -> aboveGround
+      }.to(SortedMap)
 }
 
 object Forecast {
@@ -103,7 +106,7 @@ object Forecast {
                 gfsForecast.totalCloudCover,
                 gfsForecast.convectiveCloudCover,
                 ConvectiveClouds(gfsForecast),
-                AirData(gfsForecast.atPressure),
+                AirData(gfsForecast.atPressure, gfsForecast.elevation),
                 gfsForecast.mslet,
                 gfsForecast.snowDepth,
                 gfsForecast.surfaceTemperature,

--- a/frontend/src/diagrams/Meteogram.ts
+++ b/frontend/src/diagrams/Meteogram.ts
@@ -229,8 +229,8 @@ export const airDiagramHeightAboveGroundLevel = 3500; // m
       drawWindArrow(ctx, windCenterX, airDiagram.projectY(0), meteogramColumnWidth - 6, windColor, forecast.surface.wind.u, forecast.surface.wind.v);
       // Air wind
       forecast.aboveGround
-        // Keep enly the wind values that are above the ground + 150 meters (so that arrows don’t overlap)
-        .filter((entry) => entry.elevation > forecasts.elevation + 150 && entry.elevation < forecasts.elevation + airDiagramHeightAboveGroundLevel)
+        // Keep enly the wind values that are above the ground + 100 meters (so that arrows don’t overlap)
+        .filter((entry) => entry.elevation > forecasts.elevation + 100 && entry.elevation < forecasts.elevation + airDiagramHeightAboveGroundLevel)
         .forEach((wind) => {
           drawWindArrow(ctx, windCenterX, airDiagram.projectY(elevationScale.apply(wind.elevation)), meteogramColumnWidth - 6, windColor, wind.u, wind.v);
         });


### PR DESCRIPTION
Fetch data at a few more elevation levels to get more points when drawing the meteograms or the soundings.

Unfortunately, the benefits are visible mostly for locations that are below 500 m only.

Before:

![Screenshot 2022-10-11 at 23-23-55 SoaringMeteo](https://user-images.githubusercontent.com/332812/195201842-2b389436-b4fd-4340-beee-2e48ef2759b8.png)

After:

![Screenshot 2022-10-11 at 23-23-32 SoaringMeteo](https://user-images.githubusercontent.com/332812/195201900-d677cf31-d8f4-4952-9bb0-8ab57f475567.png)

Before:

![Screenshot 2022-10-11 at 23-24-52 SoaringMeteo](https://user-images.githubusercontent.com/332812/195201954-9dd79dfb-6c3c-4108-8d86-375ac9d24f5c.png)

After:

![Screenshot 2022-10-11 at 23-24-21 SoaringMeteo](https://user-images.githubusercontent.com/332812/195201985-36d72fbf-9f2a-4b7a-9eb9-00901cf44d82.png)
