### PR TITLE
Color-code for unstable air profiles

### DIFF
--- a/frontend/src/diagrams/Sounding.tsx
+++ b/frontend/src/diagrams/Sounding.tsx
@@ -264,14 +264,23 @@ const drawSounding = (
       // Note: this is approximate, see https://en.wikipedia.org/wiki/Lapse_rate
       // We should consider applying the most precise formulas
       const lapseRate = (entry.temperature - previousTemperature) / ((entry.elevation - previousElevation) / 100);
+      const [color, width] =
+        lapseRate <= -1 ?
+          ['yellow', 4] :     // absolutely unstable air
+          (lapseRate <= -0.5 ?
+            ['orange', 3] :   // conditionally unstable air
+            (lapseRate < 0 ?
+              ['black', 2] :  // stable air
+              ['black', 1]    // inversion
+            )
+          );
       diagram.line(
         [temperatureScale.apply(previousTemperature), y0],
         [temperatureScale.apply(entry.temperature), y1],
-        'black',
+        color,
         undefined,
         true,
-        // Decrease line width according to the stability of the air mass
-        lapseRate <= -1 ? 4 : (lapseRate <= -0.6 ? 3 : (lapseRate < 0 ? 2 : 1))
+        width
       );
 
       // Dew point

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -185,17 +185,19 @@ const lazySounding =
 
 const SoundingHelp = (): JSX.Element => <>
   <p>
-    Sounding diagrams show the evolution of the temperature of the air with altitude. Here is
-    an example:
+    Sounding diagrams show the evolution of the temperature of the air with altitude (learn more
+    about sounding diagrams <a href="https://soaringmeteo.org/profilEN.pdf" target="_blank">here</a>).
+    Here is an example:
   </p>
   <div style={{ float: 'left', 'margin-right': '1em', 'min-width': `${ keyWidth + soundingWidth }px` }}>
     { lazySounding() }
   </div>
   <p>
     The horizontal axis shows the temperature, whereas the vertical axis shows the altitude. The
-    black line shows the evolution of the temperature of the air with altitude. A thin line means
-    a stable air mass. The thicker the line, the more buoyant the air mass is. The blue line shows
-    the evolution of the dew point temperature with altitude.
+    rightmost line shows the evolution of the temperature of the air with altitude. A black thin line
+    means a stable air mass, an orange line means a conditionally unstable air mass, and a yellow line
+    means an absolutely unstable air mass. The blue line shows the evolution of the dew point
+    temperature with altitude.
   </p>
   <p>
     The green area shows the boundary layer height. The white or gray areas show the presence of


### PR DESCRIPTION
I find it easier to use different colors to indicate absolutely unstable vs conditionally unstable air.

Before:

![Screenshot 2022-11-24 at 17-05-17 SoaringMeteo](https://user-images.githubusercontent.com/332812/203827617-3bd32e3f-d54c-4197-9f37-17dbb2e6ebdf.png)

After:

![Screenshot 2022-11-24 at 17-04-49 SoaringMeteo](https://user-images.githubusercontent.com/332812/203827642-d65436bf-8222-464a-84c0-dce6ff3c3629.png)
