### PR TITLE
Show thermal velocity in meteograms

### DIFF
--- a/frontend/src/diagrams/Meteogram.ts
+++ b/frontend/src/diagrams/Meteogram.ts
@@ -5,6 +5,7 @@ import { value as thqValue, colorScale as thqColorScale } from '../layers/ThQ';
 import { cloudsColorScale } from './Clouds';
 import { JSX } from 'solid-js';
 import { keyWidth, meteogramColumnWidth } from '../styles/Styles';
+import { thermalVelocityColorScale } from '../layers/ThermalVelocity';
 
 const airDiagramHeightAboveGroundLevel = 3500; // m
 
@@ -18,17 +19,21 @@ const airDiagramHeightAboveGroundLevel = 3500; // m
 
   const gutterHeight = 5; // px
 
-  // Our meteogram is made of four diagrams stacked on top of each other.
+  // Our meteogram is made of five diagrams stacked on top of each other.
   // The first one shows the ThQ
-  // The second one shows the cloud cover for high-level clouds (above 5000 m).
-  // The third one shows the boundary layer, wind, and middle-level clouds.
-  // The fourth one shows rainfalls and ground temperature.
+  // The second one shows the thermal velocity
+  // The third one shows the cloud cover for high-level clouds (above 5000 m).
+  // The fourth one shows the boundary layer, wind, and middle-level clouds.
+  // The fifth one shows rainfalls and ground temperature.
 
   const thqDiagramHeight = 20; // px
   const thqDiagramTop    = gutterHeight;
 
+  const thermalVelocityDiagramHeight = 20; // px
+  const thermalVelocityDiagramTop    = thqDiagramTop + thqDiagramHeight + gutterHeight;
+
   const highAirDiagramHeight = 20; // px
-  const highAirDiagramTop    = thqDiagramTop + thqDiagramHeight + 11 /* There needs to be enough space in case we display the isotherm 0°C */;
+  const highAirDiagramTop    = thermalVelocityDiagramTop + thermalVelocityDiagramHeight + 11 /* There needs to be enough space in case we display the isotherm 0°C */;
 
   const airDiagramHeight = 400; // px
   // The main diagram shows the air from the ground level to 3500 m above ground level
@@ -108,6 +113,23 @@ const airDiagramHeightAboveGroundLevel = 3500; // m
         'dimgray'
       )
       thqDiagram.text(`${thq}`, [columnStart + meteogramColumnWidth / 2, 6], 'dimgray', 'center');
+    });
+
+    // Thermal velocity diagram
+    const thermalVelocityDiagram = new Diagram([0, thermalVelocityDiagramTop], thermalVelocityDiagramHeight, ctx);
+
+    columns((forecast, columnStart, columnEnd) => {
+      thermalVelocityDiagram.fillRect(
+        [columnStart, 0],
+        [columnEnd, thermalVelocityDiagramHeight],
+        `${thermalVelocityColorScale.closest(forecast.thermalVelocity).css()}`
+      );
+      thermalVelocityDiagram.rect(
+        [columnStart, 0],
+        [columnEnd, thermalVelocityDiagramHeight],
+        'dimgray'
+      );
+      thermalVelocityDiagram.text(`${forecast.thermalVelocity.toFixed(1)}`, [columnStart + meteogramColumnWidth / 2, 6], 'dimgray', 'center');
     });
 
     // High altitude air diagram
@@ -353,6 +375,10 @@ const airDiagramHeightAboveGroundLevel = 3500; // m
     // Thq
     const thqDiagram = new Diagram([0, thqDiagramTop], thqDiagramHeight, leftKeyCtx);
     thqDiagram.text('XC?', [keyWidth / 2, 8], 'black', 'center', 'middle');
+
+    // Thermal velocity
+    const thermalVelocityDiagram = new Diagram([0, thermalVelocityDiagramTop], thermalVelocityDiagramHeight, leftKeyCtx);
+    thermalVelocityDiagram.text('m/s', [keyWidth / 2, 8], 'black', 'center', 'middle');
 
     // High air diagram
     const highAirDiagram = new Diagram([0, highAirDiagramTop], highAirDiagramHeight, leftKeyCtx);

--- a/frontend/src/diagrams/Sounding.tsx
+++ b/frontend/src/diagrams/Sounding.tsx
@@ -320,6 +320,18 @@ const drawSounding = (
       [forecast.surface.temperature, forecast.surface.dewPoint, elevation]
     );
 
+    // Thermal velocity
+    const projectedSurfaceTemperature = temperatureScale.apply(forecast.surface.temperature);
+    const projectedElevation = elevationScale.apply(elevation);
+    const projectedBoundaryLayerHeight = elevationScale.apply(elevation + forecast.boundaryLayer.height);
+    diagram.text(
+      `${forecast.thermalVelocity.toFixed(1)} m/s`,
+      [projectedSurfaceTemperature, (projectedElevation + projectedBoundaryLayerHeight) / 2],
+      'black',
+      'right',
+      'middle'
+    );
+
 };
 
 const computeSoundingHeightAndMaxElevation = (zoomed: boolean, elevation: number, forecast: DetailedForecast): [number, number] => {

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -137,13 +137,14 @@ const MeteogramHelp = (): JSX.Element => <>
   </div>
   <p>
     The top row (“XC?”) shows the estimated cross-country flying potential (between 0% and 100%).
-    The higher the number, the higher the chances to fly long distances. Select the
+    The higher the number, the higher the chances to fly long distances. It takes into account the
+    boundary layer depth, the average thermal velocity, the wind speed, and the sunshine. Select the
     layer “{ xcFlyingPotentialLayer.name }” in the map view to learn more about how it works.
   </p>
   <p>
-    The second row (“m/s”) shows the estimated average thermal velocity (in m/s). Values above 1 m/s
-    usually mean that thermals should be just strong enough to stay in the air. Values above 2 m/s
-    mean good thermals.
+    The second row (“m/s”) shows the estimated average thermal velocity (in m/s) within the boundary layer.
+    Values above 1 m/s usually mean that thermals should be just strong enough to stay in the air. Values
+    above 2 m/s mean good thermals.
   </p>
   <p>
     Below those numbers, the “airgram” shows various properties of the air at the selected location
@@ -154,7 +155,7 @@ const MeteogramHelp = (): JSX.Element => <>
     The <a href="https://en.wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
     boundary layer</a> is shown in green. It tells us how high thermals will be at a given time.
     In this example, we see that they reach { fakeData.groundLevel + fakeData.maxDepth } m in the middle of the
-    last day.
+    last day. It is good to have a boundary layer of at least 1000 m above the ground level to fly cross-country.
   </p>
   <p>
     The wind and clouds are also shown in that diagram at various elevation levels. For
@@ -219,8 +220,8 @@ const SoundingHelp = (): JSX.Element => <>
   </p>
   <p>
     The text “2.5 m/s” (in the middle of the green area, on the right of the diagram) tells you the
-    estimated average thermal velocity. Values above 1 m/s usually mean that thermals should be just
-    strong enough to stay in the air. Values above 2 m/s mean good thermals.
+    estimated average thermal velocity within the boundary layer. Values above 1 m/s usually mean
+    that thermals should be just strong enough to stay in the air. Values above 2 m/s mean good thermals.
   </p>
   <p>
     By default, the diagram shows only the airmass within the boundary layer and a couple of thousand

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -141,7 +141,12 @@ const MeteogramHelp = (): JSX.Element => <>
     layer “{ xcFlyingPotentialLayer.name }” in the map view to learn more about how it works.
   </p>
   <p>
-    Below that number, the “airgram” shows various properties of the air at the selected location
+    The second row (“m/s”) shows the estimated average thermal velocity (in m/s). Values above 1 m/s
+    usually mean that thermals should be just strong enough to stay in the air. Values above 2 m/s
+    mean good thermals.
+  </p>
+  <p>
+    Below those numbers, the “airgram” shows various properties of the air at the selected location
     over time. The scale on the left shows the altitude. In this example, it starts at { fakeData.groundLevel } m,
     which is the altitude of the selected location as seen by the current forecast model.
   </p>

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -218,6 +218,11 @@ const SoundingHelp = (): JSX.Element => <>
     wind barbells.
   </p>
   <p>
+    The text “2.5 m/s” (in the middle of the green area, on the right of the diagram) tells you the
+    estimated average thermal velocity. Values above 1 m/s usually mean that thermals should be just
+    strong enough to stay in the air. Values above 2 m/s mean good thermals.
+  </p>
+  <p>
     By default, the diagram shows only the airmass within the boundary layer and a couple of thousand
     meters above it. You can expand the diagram to see the whole troposphere by clicking to the button
     on the top right corner.

--- a/frontend/src/layers/ThermalVelocity.tsx
+++ b/frontend/src/layers/ThermalVelocity.tsx
@@ -22,7 +22,7 @@ class ThermalVelocity implements Renderer {
 
 }
 
-const thermalVelocityColorScale = new ColorScale([
+export const thermalVelocityColorScale = new ColorScale([
   [0.25, new Color(0x33, 0x33, 0x33, 1)],
   [0.50, new Color(0x99, 0x00, 0x99, 1)],
   [0.75, new Color(0xff, 0x00, 0x00, 1)],


### PR DESCRIPTION
An alternative to #37. We add another line below the XC potential to show the estimated thermal velocity:

![Screenshot 2022-12-17 at 12-00-31 SoaringMeteo](https://user-images.githubusercontent.com/332812/208257092-fb71ab8a-3349-4ebf-9f85-dce4b785df64.png)

![Screenshot 2022-12-17 at 11-53-14 SoaringMeteo](https://user-images.githubusercontent.com/332812/208257096-1aec8ba8-3962-47e9-9f8b-d95218829df8.png)

I am not 100% sure about this. On the one hand I would like this information to be shown somehow, but on the other hand I feel like there is maybe too much information… Maybe I could display it only if the user enabled some setting (“advanced meteograms”).