### PR TITLE
Cap the boundary layer with the cloud base

### DIFF
--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/Forecast.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable.SortedMap
 case class Forecast(
   time: OffsetDateTime,
   elevation: Length,
-  boundaryLayerDepth: Length, // m AGL
+  soaringLayerDepth: Length, // m AGL
   boundaryLayerWind: Wind,
   thermalVelocity: Velocity,
   totalCloudCover: Int, // Between 0 and 100
@@ -98,7 +98,7 @@ object Forecast {
             gfsForecastsByLocation.map { case (point, gfsForecast) =>
               val (totalRain, convectiveRain) = extractTotalAndConvectiveRain(point, gfsForecast)
               val maybeConvectiveClouds = ConvectiveClouds(gfsForecast)
-              val soaringDepth =
+              val soaringLayerDepth =
                 maybeConvectiveClouds match {
                   case None => gfsForecast.boundaryLayerDepth
                   case Some(convectiveClouds) =>
@@ -109,7 +109,7 @@ object Forecast {
               val forecast = Forecast(
                 gfsForecast.time,
                 gfsForecast.elevation,
-                soaringDepth,
+                soaringLayerDepth,
                 gfsForecast.boundaryLayerWind,
                 Thermals.velocity(gfsForecast),
                 gfsForecast.totalCloudCover,
@@ -145,7 +145,7 @@ object Forecast {
     Encoder.instance { forecast =>
       val winds = Winds(forecast)
       Json.arr(
-        Json.fromInt(forecast.boundaryLayerDepth.toMeters.round.toInt),
+        Json.fromInt(forecast.soaringLayerDepth.toMeters.round.toInt),
         Json.fromInt(forecast.boundaryLayerWind.u.toKilometersPerHour.round.toInt),
         Json.fromInt(forecast.boundaryLayerWind.v.toKilometersPerHour.round.toInt),
         Json.fromInt(forecast.totalCloudCover),

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/LocationForecasts.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/LocationForecasts.scala
@@ -64,7 +64,7 @@ object LocationForecasts {
       forecasts.map { forecast =>
           DetailedForecast(
             forecast.time,
-            forecast.boundaryLayerDepth,
+            forecast.soaringLayerDepth,
             forecast.boundaryLayerWind,
             forecast.thermalVelocity,
             forecast.convectiveCloudCover,

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/Winds.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/Winds.scala
@@ -35,7 +35,7 @@ object Winds {
 
     Winds(
       at(Meters(300)),
-      at(forecast.boundaryLayerDepth)
+      at(forecast.soaringLayerDepth)
     )
   }
 

--- a/frontend/src/data/Forecast.ts
+++ b/frontend/src/data/Forecast.ts
@@ -1,7 +1,7 @@
 import { ForecastMetadata } from "./ForecastMetadata";
 
 export type ForecastPoint = {
-  boundaryLayerDepth: number // m
+  soaringLayerDepth: number // m
   thermalVelocity: number // m/s
   uWind: number // km/h
   vWind: number // km/h
@@ -27,7 +27,7 @@ export class Forecast {
     const pointData = this.data[`${longitude / modelResolution},${latitude / modelResolution}`];
     if (pointData !== undefined) {
       return {
-        boundaryLayerDepth: pointData[0],
+        soaringLayerDepth: pointData[0],
         uWind: pointData[1],
         vWind: pointData[2],
         cloudCover: pointData[3] / 100,
@@ -53,7 +53,7 @@ export type ForecastData = {
 
 // WARN Must be consistent with `Forecast` JSON encoder in the backend
 type ForecastPointData = [
-  number, // Boundary layer height
+  number, // Soaring layer depth
   number, // Wind: u component
   number, // Wind: v component
   number, // Cloud cover between 0 and 100

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -227,7 +227,7 @@ const SoundingHelp = (props: { domain: Domain }): JSX.Element => <>
     temperature with altitude.
   </p>
   <p>
-    The green area shows the boundary layer height. The white or gray areas show the presence of
+    The green area shows the soaring layer. The white or gray areas show the presence of
     clouds. On the left, the wind speed and direction is shown at various altitude levels by the
     wind barb.
   </p>

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -163,10 +163,11 @@ const MeteogramHelp = (props: { domain: Domain }): JSX.Element => <>
     which is the altitude of the selected location as seen by the current forecast model.
   </p>
   <p>
-    The green area shows how high we can soar at a given time. In case of “blue thermals”, we show
+    The green area shows the soaring layer, which is the part of the atmosphere where we can expect to find thermals
+    and soar. The height of the soaring layer tells us how high we can soar. In case of “blue thermals”,
+    the soaring layer is
     the <a href="https://en.wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
-    boundary layer</a> depth. Otherwise (if there are cumulus clouds), we show the altitude of the
-    cloud base above the ground level.
+    boundary layer</a>. Otherwise (if there are cumulus clouds), it stops at the cloud base.
     In this example, we see that the soaring layer reaches { fakeData.groundLevel + fakeData.maxDepth } m in the middle of the
     last day. It is good to have a soaring layer of at least 750 m above the ground level to fly cross-country.
   </p>
@@ -227,7 +228,8 @@ const SoundingHelp = (props: { domain: Domain }): JSX.Element => <>
     temperature with altitude.
   </p>
   <p>
-    The green area shows the soaring layer. The white or gray areas show the presence of
+    The green area shows the soaring layer, which is the part of the atmosphere where we can expect to
+    find thermals and soar. The white or gray areas show the presence of
     clouds. On the left, the wind speed and direction is shown at various altitude levels by the
     wind barb.
   </p>

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -167,8 +167,8 @@ const MeteogramHelp = (props: { domain: Domain }): JSX.Element => <>
     the <a href="https://en.wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
     boundary layer</a> depth. Otherwise (if there are cumulus clouds), we show the altitude of the
     cloud base above the ground level.
-    In this example, we see that they reach { fakeData.groundLevel + fakeData.maxDepth } m in the middle of the
-    last day. It is good to have a boundary layer of at least 750 m above the ground level to fly cross-country.
+    In this example, we see that the soaring layer reaches { fakeData.groundLevel + fakeData.maxDepth } m in the middle of the
+    last day. It is good to have a soaring layer of at least 750 m above the ground level to fly cross-country.
   </p>
   <p>
     The wind and clouds are also shown in that diagram at various elevation levels. For

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -91,7 +91,7 @@ const MapHelp = (props: { domain: Domain, layers: Layers }): JSX.Element => {
 
   return <>
     <p>
-      Soaringmeteo is a free weather forecast website developped by passionate pilots. Please consider making
+      Soaringmeteo is a free weather forecast website developed by passionate pilots. Please consider making
       a <a href='https://soaringmeteo.org/don.html'>donation</a> to help us cover our cost.
     </p>
     <p>
@@ -163,10 +163,12 @@ const MeteogramHelp = (props: { domain: Domain }): JSX.Element => <>
     which is the altitude of the selected location as seen by the current forecast model.
   </p>
   <p>
-    The <a href="https://en.wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
-    boundary layer</a> is shown in green. It tells us how high thermals will be at a given time.
+    The green area shows how high we can soar at a given time. In case of “blue thermals”, we show
+    the <a href="https://en.wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
+    boundary layer</a> depth. Otherwise (if there are cumulus clouds), we show the altitude of the
+    cloud base above the ground level.
     In this example, we see that they reach { fakeData.groundLevel + fakeData.maxDepth } m in the middle of the
-    last day. It is good to have a boundary layer of at least 1000 m above the ground level to fly cross-country.
+    last day. It is good to have a boundary layer of at least 750 m above the ground level to fly cross-country.
   </p>
   <p>
     The wind and clouds are also shown in that diagram at various elevation levels. For

--- a/frontend/src/layers/BoundaryLayerDepth.tsx
+++ b/frontend/src/layers/BoundaryLayerDepth.tsx
@@ -13,7 +13,7 @@ export class BoundaryLayerDepth implements Renderer {
 
   summary(forecastAtPoint: ForecastPoint): Array<[string, string]> {
     return [
-      ["Boundary layer depth", `${ forecastAtPoint.boundaryLayerDepth } m`]
+      ["Boundary layer depth (or cloud base)", `${ forecastAtPoint.boundaryLayerDepth } m`]
     ]
   }
 

--- a/frontend/src/layers/Layers.tsx
+++ b/frontend/src/layers/Layers.tsx
@@ -1,7 +1,7 @@
 import { JSX, Show } from "solid-js";
 import { drawWindArrow } from "../shapes";
 import { boundaryLayerDepthKey, boundaryLayerTopWindKey, boundaryLayerWindKey, cloudCoverKey, cumuliDepthKey, noneKey, rainKey, Domain, surfaceWindKey, thermalVelocityKey, xcFlyingPotentialKey, _300MAGLWindKey } from "../State";
-import { boundaryDepthColorScale, BoundaryLayerDepth } from "./BoundaryLayerDepth";
+import { soaringLayerDepthColorScale, SoaringLayerDepth } from "./SoaringLayerDepth";
 import { CloudCover, cloudCoverColorScale } from "./CloudCover";
 import { CumuliDepth, cumuliDepthColorScale } from "./CumuliDepth";
 import { colorScaleEl, Layer, windColor } from "./Layer";
@@ -29,8 +29,8 @@ export class Layers {
       <>
         <p>
           The XC flying potential index is a single indicator that takes into account
-          the boundary layer depth, the sunshine, and the average wind speed within the
-          boundary layer. Deep boundary layer, strong sunshine, and low wind speeds
+          the soaring layer depth, the sunshine, and the average wind speed within the
+          boundary layer. Deep soaring layer, strong sunshine, and low wind speeds
           increase the value of this indicator.
         </p>
         <p>
@@ -42,10 +42,10 @@ export class Layers {
 
     const boundaryLayerDepthLayer = new Layer(
       boundaryLayerDepthKey,
-      'Boundary Layer Depth',
-      'Boundary layer depth (or cloud base)',
-      forecast => new BoundaryLayerDepth(forecast),
-      colorScaleEl(boundaryDepthColorScale, value => `${value} m `),
+      'Soaring Layer Depth',
+      'Soaring layer depth',
+      forecast => new SoaringLayerDepth(forecast),
+      colorScaleEl(soaringLayerDepthColorScale, value => `${value} m `),
       <>
         <p>
           This value tells us how high above the ground level we can soar. For instance, a value of 850 m

--- a/frontend/src/layers/Layers.tsx
+++ b/frontend/src/layers/Layers.tsx
@@ -48,7 +48,7 @@ export class Layers {
       colorScaleEl(soaringLayerDepthColorScale, value => `${value} m `),
       <>
         <p>
-          This value tells us how high above the ground level we can soar. For instance, a value of 850 m
+          The soaring layer is the area of the atmosphere where we can soar. For instance, a value of 850 m
           means that we can soar up to 850 m above the ground level. Values higher than 750 m are preferable
           to fly cross-country.
         </p>

--- a/frontend/src/layers/Layers.tsx
+++ b/frontend/src/layers/Layers.tsx
@@ -43,14 +43,20 @@ export class Layers {
     const boundaryLayerDepthLayer = new Layer(
       boundaryLayerDepthKey,
       'Boundary Layer Depth',
-      'Boundary layer depth',
+      'Boundary layer depth (or cloud base)',
       forecast => new BoundaryLayerDepth(forecast),
       colorScaleEl(boundaryDepthColorScale, value => `${value} m `),
       <>
         <p>
-          The <a href="https://wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
-          boundary layer</a> tells us how high the thermals will be at a given location and time.
-          Deep boundary layers are great for flying cross-country.
+          This value tells us how high above the ground level we can soar. For instance, a value of 850 m
+          means that we can soar up to 850 m above the ground level. Values higher than 750 m are preferable
+          to fly cross-country.
+        </p>
+        <p>
+          In case of “blue thermals”, we show
+          the <a href="https://wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
+          boundary layer</a> depth, otherwise (if there are cumulus clouds) we show the altitude of the
+          cloud base above the ground level.
         </p>
         <p>
           The color scale is shown on the bottom left of the screen.

--- a/frontend/src/layers/Layers.tsx
+++ b/frontend/src/layers/Layers.tsx
@@ -48,15 +48,15 @@ export class Layers {
       colorScaleEl(soaringLayerDepthColorScale, value => `${value} m `),
       <>
         <p>
-          The soaring layer is the area of the atmosphere where we can soar. For instance, a value of 850 m
-          means that we can soar up to 850 m above the ground level. Values higher than 750 m are preferable
-          to fly cross-country.
+          The soaring layer is the area of the atmosphere where we can expect to find thermals and
+          soar. The depth of the soaring layer tells us how high we can soar. For instance, a value
+          of 850 m means that we can soar up to 850 m above the ground level. Values higher than
+          750 m are preferable to fly cross-country.
         </p>
         <p>
-          In case of “blue thermals”, we show
+          In case of “blue thermals”, the soaring layer is
           the <a href="https://wikipedia.org/wiki/Planetary_boundary_layer" target="_blank">planetary
-          boundary layer</a> depth, otherwise (if there are cumulus clouds) we show the altitude of the
-          cloud base above the ground level.
+          boundary layer</a>, otherwise (if there are cumulus clouds) it stops at the cloud base.
         </p>
         <p>
           The color scale is shown on the bottom left of the screen.

--- a/frontend/src/layers/SoaringLayerDepth.tsx
+++ b/frontend/src/layers/SoaringLayerDepth.tsx
@@ -3,30 +3,30 @@ import * as L from 'leaflet';
 import { ColorScale, Color } from "../ColorScale";
 import { Renderer } from "../map/CanvasLayer";
 
-export class BoundaryLayerDepth implements Renderer {
+export class SoaringLayerDepth implements Renderer {
 
   constructor(readonly forecast: Forecast) {}
 
   renderPoint(forecastAtPoint: ForecastPoint, topLeft: L.Point, bottomRight: L.Point, ctx: CanvasRenderingContext2D): void {
-    drawBoundaryLayerDepth(forecastAtPoint, topLeft, bottomRight, ctx);
+    drawSoaringLayerDepth(forecastAtPoint, topLeft, bottomRight, ctx);
   }
 
   summary(forecastAtPoint: ForecastPoint): Array<[string, string]> {
     return [
-      ["Boundary layer depth (or cloud base)", `${ forecastAtPoint.boundaryLayerDepth } m`]
+      ["Soaring layer depth", `${ forecastAtPoint.soaringLayerDepth } m`]
     ]
   }
 
 }
 
-const drawBoundaryLayerDepth = (forecastAtPoint: ForecastPoint, topLeft: L.Point, bottomRight: L.Point, ctx: CanvasRenderingContext2D) => {
-  const blh = forecastAtPoint.boundaryLayerDepth;
-  const color = boundaryDepthColorScale.closest(blh);
+const drawSoaringLayerDepth = (forecastAtPoint: ForecastPoint, topLeft: L.Point, bottomRight: L.Point, ctx: CanvasRenderingContext2D) => {
+  const blh = forecastAtPoint.soaringLayerDepth;
+  const color = soaringLayerDepthColorScale.closest(blh);
   ctx.fillStyle = `rgba(${color.red}, ${color.green}, ${color.blue}, 0.25)`;
   ctx.fillRect(topLeft.x, topLeft.y, bottomRight.x - topLeft.x, bottomRight.y - topLeft.y);
 }
 
-export const boundaryDepthColorScale = new ColorScale([
+export const soaringLayerDepthColorScale = new ColorScale([
   [250,  new Color(0x33, 0x33, 0x33, 1)],
   [500,  new Color(0x99, 0x00, 0x99, 1)],
   [750,  new Color(0xff, 0x00, 0x00, 1)],

--- a/frontend/src/layers/ThQ.tsx
+++ b/frontend/src/layers/ThQ.tsx
@@ -24,7 +24,7 @@ export class ThQ implements Renderer {
     if (forecastAtPoint !== undefined) {
       const thq = value(
         forecastAtPoint.thermalVelocity,
-        forecastAtPoint.boundaryLayerDepth,
+        forecastAtPoint.soaringLayerDepth,
         forecastAtPoint.uWind,
         forecastAtPoint.vWind
       );
@@ -40,36 +40,36 @@ export class ThQ implements Renderer {
   summary(forecastAtPoint: ForecastPoint): Array<[string, string]> {
     const thq = value(
       forecastAtPoint.thermalVelocity,
-      forecastAtPoint.boundaryLayerDepth,
+      forecastAtPoint.soaringLayerDepth,
       forecastAtPoint.uWind,
       forecastAtPoint.vWind
     );
 
     return [
-      ["XC Flying Potential",  `${thq}%`],
-      ["Boundary layer depth (or cloud base)", `${forecastAtPoint.boundaryLayerDepth} m`],
-      ["Thermal velocity",     `${forecastAtPoint.thermalVelocity} m/s`],
-      ["Total cloud cover",    `${Math.round(forecastAtPoint.cloudCover * 100)}%`]
+      ["XC Flying Potential", `${thq}%`],
+      ["Soaring layer depth", `${forecastAtPoint.soaringLayerDepth} m`],
+      ["Thermal velocity",    `${forecastAtPoint.thermalVelocity} m/s`],
+      ["Total cloud cover",   `${Math.round(forecastAtPoint.cloudCover * 100)}%`]
     ]
   }
 
 }
 
 /**
- * @param thermalVelocity    Thermal velocity in m/s
- * @param boundaryLayerDepth Depth of the boundary layer in meters
- * @param uWind              U part of wind in boundary layer in km/h
- * @param vWind              V part of wind in boundary layer in km/h
+ * @param thermalVelocity   Thermal velocity in m/s
+ * @param soaringLayerDepth Depth of the boundary layer in meters
+ * @param uWind             U part of wind in boundary layer in km/h
+ * @param vWind             V part of wind in boundary layer in km/h
  * @returns A value between 0 and 100
  */
-export const value = (thermalVelocity: number, boundaryLayerDepth: number, uWind: number, vWind: number): number => {
+export const value = (thermalVelocity: number, soaringLayerDepth: number, uWind: number, vWind: number): number => {
   // Thermal velocity
   // coeff is 50% for a 1.55 m/s
   const thermalVelocityCoeff = logistic(thermalVelocity, 1.55, 5);
 
-  // Boundary Layer Depth
-  // coeff is 50% for a boundary layer depth of 400 m
-  const bldCoeff = logistic(boundaryLayerDepth, 400, 4);
+  // Soaring Layer Depth
+  // coeff is 50% for a soaring layer depth of 400 m
+  const bldCoeff = logistic(soaringLayerDepth, 400, 4);
 
   const thermalCoeff = (2 * thermalVelocityCoeff + bldCoeff) / 3;
 

--- a/frontend/src/layers/ThQ.tsx
+++ b/frontend/src/layers/ThQ.tsx
@@ -47,7 +47,7 @@ export class ThQ implements Renderer {
 
     return [
       ["XC Flying Potential",  `${thq}%`],
-      ["Boundary layer depth", `${forecastAtPoint.boundaryLayerDepth} m`],
+      ["Boundary layer depth (or cloud base)", `${forecastAtPoint.boundaryLayerDepth} m`],
       ["Thermal velocity",     `${forecastAtPoint.thermalVelocity} m/s`],
       ["Total cloud cover",    `${Math.round(forecastAtPoint.cloudCover * 100)}%`]
     ]

--- a/frontend/src/map/CanvasLayer.ts
+++ b/frontend/src/map/CanvasLayer.ts
@@ -127,7 +127,7 @@ export const viewPoint = (forecast: Forecast, averagingFactor: number, lat: numb
     return points[0]
   } else if (points.length > 1) {
     const sumPoint: ForecastPoint = {
-      boundaryLayerDepth: 0,
+      soaringLayerDepth: 0,
       thermalVelocity: 0,
       uWind: 0,
       vWind: 0,
@@ -142,7 +142,7 @@ export const viewPoint = (forecast: Forecast, averagingFactor: number, lat: numb
       cumuliDepth: 0
     };
     points.forEach(point => {
-      sumPoint.boundaryLayerDepth += point.boundaryLayerDepth;
+      sumPoint.soaringLayerDepth += point.soaringLayerDepth;
       sumPoint.thermalVelocity += point.thermalVelocity;
       sumPoint.uWind += point.uWind;
       sumPoint.vWind += point.vWind;
@@ -158,7 +158,7 @@ export const viewPoint = (forecast: Forecast, averagingFactor: number, lat: numb
     })
     const n = points.length;
     return {
-      boundaryLayerDepth: sumPoint.boundaryLayerDepth / n,
+      soaringLayerDepth: sumPoint.soaringLayerDepth / n,
       thermalVelocity: sumPoint.thermalVelocity / n,
       uWind: sumPoint.uWind / n,
       vWind: sumPoint.vWind / n,


### PR DESCRIPTION
In the meteograms and in the XC flying potential index, we used to overestimate the “soaring ceiling” in case of a low cloud base. Basically, we were ignoring the fact that we can’t really go higher than the cloud base (in VFR).

We fix this issue by capping the boundary layer to the cloud base, in case of the presence of cumulus clouds.


---

Before:

![Screenshot 2023-01-15 at 12-58-22 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540254-4a09fb3d-1b00-405e-9c4d-a7956c31aa6f.png)

After (look especially at a day like the 20th of January):

![Screenshot 2023-01-15 at 12-58-35 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540261-ad49a5dd-ef17-44f8-84fc-b86a5e9d7c25.png)

---

Before:

![Screenshot 2023-01-15 at 13-09-20 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540279-b9c79992-7184-420b-a655-0fcf0e02f743.png)

After:

![Screenshot 2023-01-15 at 13-09-42 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540289-05982b20-4253-437e-9768-5fc332086284.png)


----

Before:

![Screenshot 2023-01-15 at 13-10-39 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540299-30dae45d-ad5a-4bc5-8625-532ca8fdc8b0.png)


After:

![Screenshot 2023-01-15 at 13-10-55 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540311-1987b5d8-76d6-4593-b573-52e92b664e79.png)


---

Before:

![Screenshot 2023-01-15 at 13-12-05 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540319-a51fc9a9-1310-470d-b44e-b930e7657bec.png)

After:

![Screenshot 2023-01-15 at 13-12-12 SoaringMeteo](https://user-images.githubusercontent.com/332812/212540323-74aab352-c0f0-42a4-90bb-99cfff98352a.png)
