### PR TITLE
Support breaking changes in the forecast data format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+## Evolving the Format of the Forecast Data
+
+The frontend consumes the forecast data produced by the backend, so both parties need to agree on their format.
+Furthermore, the frontend also reads several forecast data in the past (users can show the data from the latest
+forecast run, or from older runs as well). This has consequences on how the format of the forecast data produced
+by the backend can evolve:
+
+- We can add or remove optional fields,
+- We can remove non-optional fields (the frontend will simply ignore those fields on the older forecast data).
+
+However, to add non-optional fields we have to perform the following procedure:
+
+- Bump the format version both in the backend and the frontend
+  - `backend/src/main/scala/org/soaringmeteo/gfs/out/package.scala`
+  - `frontend/src/data/ForecastMetadata.ts`
+- Perform a two-stage deployment
+  1. Deploy the backend,
+  2. Only after the backend has produced some data, we can deploy the frontend (in the meantime, the frontend
+     still shows the older forecast data).

--- a/backend/src/main/scala/org/soaringmeteo/gfs/out/package.scala
+++ b/backend/src/main/scala/org/soaringmeteo/gfs/out/package.scala
@@ -9,4 +9,11 @@ package object out {
   /** Several forecasts, indexed by hour after initialization time */
   type ForecastsByHour = Map[Int, ForecastsByLocation]
 
+  /**
+   * Version of the format of the forecast data we produce.
+   * We need to bump this number everytime we introduce incompatibilities (e.g. adding a non-optional field).
+   * Make sure to also bump the `formatVersion` in the frontend (see frontend/src/data/ForecastMetadata.ts).
+   */
+  val formatVersion = 0
+
 }

--- a/frontend/src/data/ForecastMetadata.ts
+++ b/frontend/src/data/ForecastMetadata.ts
@@ -8,8 +8,10 @@ type ForecastMetadataData = {
   prev?: [string, string]  // e.g., ["2020-04-13T18-forecast.json", "2020-04-13T18:00:00Z"]
 }
 
+// Version of the forecast data format we consume (see backend/src/main/scala/org/soaringmeteo/package.scala)
+const formatVersion = 0
 // Base path to access forecast data
-const dataPath = "data"
+const dataPath = `data/${formatVersion}`
 export class ForecastMetadata {
   readonly initS: string
   readonly init: Date


### PR DESCRIPTION
Currently, changing the format of the forecast data produced by the server is delicate to handle: the frontend still shows the older (incompatible) forecast runs, and more importantly there is a short period of time where the frontend is not able to consume the data produced by the server.

We now indicate the version of the format of the data produced by the backend and consumed by the frontend so that whenever we need to change the format of the data produced by the backend, we can simply delay the deployment of the frontend and only when we will deploy the updated frontend then the new forecast data will be consumed (in the meantime, the frontend will still work with the older forecast data).