### PR TITLE
Add more information to the bottom of meteograms and sounding diagrams

### DIFF
--- a/frontend/src/State.tsx
+++ b/frontend/src/State.tsx
@@ -23,7 +23,7 @@ export type State = {
   detailedView: undefined | [LocationForecasts, DetailedViewType]
 }
 
-type DetailedViewType = 'meteogram' | 'sounding'
+export type DetailedViewType = 'meteogram' | 'sounding'
 
 // Keys used to store the current display settings in the local storage
 const selectedPrimaryLayerKey   = 'selected-primary-layer';
@@ -162,6 +162,7 @@ export class Domain {
 
   /** Display the detailed view (meteogram or sounding) at the given location */
   showLocationForecast(latitude: number, longitude: number, viewType: DetailedViewType): void {
+    // TODO Optimization if state.detailedView already contains data for the given latitude,longitude
     this.state.forecastMetadata
       .fetchLocationForecasts(latitude, longitude)
       .then(locationForecasts => {

--- a/frontend/src/diagrams/Sounding.tsx
+++ b/frontend/src/diagrams/Sounding.tsx
@@ -384,7 +384,7 @@ const drawSounding = (
 const computeSoundingHeightAndMaxElevation = (zoomed: boolean, elevation: number, forecast: DetailedForecast): [number, number] => {
   const maxElevation = zoomed ? (elevation + forecast.boundaryLayer.soaringLayerDepth + 2000) : 12000; // m
 
-  const availableHeight = window.innerHeight - 38 /* top time selector */ - 50 /* bottom time selector */;
+  const availableHeight = window.innerHeight - 38 /* top time selector */ - 50 /* bottom time selector */ - 27 /* text information and help */;
   const preferredHeight = (maxElevation - elevation) / 10; // Arbitrary factor to make the diagram visually nice
   const canvasHeight = Math.min(preferredHeight, availableHeight);
   return [canvasHeight, maxElevation];

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -24,6 +24,7 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
         'background-color': 'white'
       }}
       onClick={ () => makeVisible(true) }
+      title="Help"
     >
       ?
     </div>;


### PR DESCRIPTION
Also include a button to switch from meteograms to sounding diagrams and vice versa, and a button to show the help.

Fixes #63

![image](https://user-images.githubusercontent.com/332812/235368533-2f325f2f-7912-468c-9992-de496f7bc660.png)
