### PR TITLE
Move thunderstorm icon to the “rain diagram” and scale the icon according to the risk of thunderstorm

### DIFF
--- a/frontend/src/diagrams/Diagram.ts
+++ b/frontend/src/diagrams/Diagram.ts
@@ -47,7 +47,8 @@ export class Diagram {
     this.ctx.restore();
   }
 
-  fillShape(points: Array<Point>, style: string): void {
+  fillShape(points: Array<Point>, style: string, strokeStyle?: string): void {
+    this.ctx.save();
     this.ctx.fillStyle = style;
     this.ctx.beginPath();
     points.forEach(([x, y]) => {
@@ -55,6 +56,12 @@ export class Diagram {
     });
     this.ctx.closePath();
     this.ctx.fill();
+    if (strokeStyle !== undefined) {
+      this.ctx.strokeStyle = strokeStyle;
+      this.ctx.lineWidth = 1;
+      this.ctx.stroke();
+    }
+    this.ctx.restore();
   }
 
   text(content: string, location: Point, style: string, align?: CanvasTextAlign, baseline?: CanvasTextBaseline): void {

--- a/frontend/src/diagrams/Meteogram.ts
+++ b/frontend/src/diagrams/Meteogram.ts
@@ -398,7 +398,7 @@ const drawMeteogram = (
         case 3: lightningStyle = 'red'; break
         default: lightningStyle = 'purple'; break
       }
-      rainDiagram.fillShape(lightningShape(x, y, width), lightningStyle);
+      rainDiagram.fillShape(lightningShape(x, y, width), lightningStyle, 'gray');
     }
     previousLightningX = previousLightningX + dayWidth;
   });

--- a/frontend/src/diagrams/Meteogram.ts
+++ b/frontend/src/diagrams/Meteogram.ts
@@ -317,25 +317,6 @@ const drawMeteogram = (
     }
   });
 
-  // Thunderstorm risk
-  let previousLightningX = 0;
-  forecasts.dayForecasts.forEach(forecast => {
-    const lightningWidth = forecast.forecasts.length * meteogramColumnWidth;
-    const x = previousLightningX + lightningWidth / 2;
-    const y = airDiagramHeight - lightningWidth / 2;
-    if (forecast.thunderstormRisk > 0) {
-      let lightningStyle: string;
-      switch (forecast.thunderstormRisk) {
-        case 1: lightningStyle = 'yellow'; break
-        case 2: lightningStyle = 'orange'; break
-        case 3: lightningStyle = 'red'; break
-        default: lightningStyle = 'purple'; break
-      }
-      airDiagram.fillShape(lightningShape(x, y, lightningWidth), lightningStyle);
-    }
-    previousLightningX = previousLightningX + lightningWidth;
-  });
-
   // Wind
   columns((forecast, columnStart, _) => {
     const windCenterX = columnStart + meteogramColumnWidth / 2;
@@ -400,6 +381,29 @@ const drawMeteogram = (
   // Rain diagram
   const rainDiagram = new Diagram([0, rainDiagramTop], rainDiagramHeight, ctx);
 
+  // Thunderstorm risk
+  let previousLightningX = 0;
+  forecasts.dayForecasts.forEach(forecast => {
+    const dayWidth = forecast.forecasts.length * meteogramColumnWidth;
+    if (forecast.thunderstormRisk > 0) {
+      const lightningMaxWidth = dayWidth / 3;
+      const lightningMinWidth = lightningMaxWidth * 3 / 4;
+      const width = lightningMinWidth + lightningMaxWidth * (forecast.thunderstormRisk - 1) / 3;
+      const x = previousLightningX + dayWidth / 2;
+      const y = rainDiagramHeight - width / 2;
+      let lightningStyle: string;
+      switch (forecast.thunderstormRisk) {
+        case 1: lightningStyle = 'yellow'; break
+        case 2: lightningStyle = 'orange'; break
+        case 3: lightningStyle = 'red'; break
+        default: lightningStyle = 'purple'; break
+      }
+      rainDiagram.fillShape(lightningShape(x, y, width), lightningStyle);
+    }
+    previousLightningX = previousLightningX + dayWidth;
+  });
+
+  // Rain
   columns((forecast, columnStart, columnEnd) => {
     rainDiagram.fillRect(
       [columnStart, 0],

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -196,6 +196,7 @@ const MeteogramHelp = (props: { domain: Domain }): JSX.Element => <>
     and for the temperature on the right. In the example, a few millimeters of rain are expected
     the first day, and the air gets dryer the third day (the dew point temperature decreases).
   </p>
+  <p>Last, the presence of a lightning picture indicates a risk of thunderstorm during the day. The larger the picture, the higher the risk of thunderstorm.</p>
   <p>
     According to this diagram, the best day for flying is the third day, although the wind may
     be a little bit too strong in the afternoon.

--- a/frontend/src/help/data.ts
+++ b/frontend/src/help/data.ts
@@ -70,7 +70,7 @@ const locationData: LocationForecastsData = {
       ]
     },
     {
-      "th": 0,
+      "th": 1,
       "h": [
         {
           "t": "2022-11-04T09:00:00Z",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/332812/236611653-d22b6c8d-7ec3-4467-87d2-1d510f56b43f.png)

Credits to @Boran for the idea.