### PR TITLE
Improve the way to select the day of forecast

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "solid-js": "1.4.8"
   },
   "devDependencies": {
+    "@css-hooks/solid": "1.2.1",
     "@types/proj4": "2.5.4",
     "serve-static": "1.15.0",
     "typescript": "4.6.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {Domain, gfsModel, wrfModel} from './State';
 import { Burger } from './Burger';
 import { Attribution } from './map/Attribution';
 import {noLayer} from "./layers/None";
+import { css } from "./css-hooks";
 
 const Help = lazy(() => import('./help/Help').then(module => ({ default: module.Help })));
 const PeriodSelectors = lazy(() => import('./PeriodSelector').then(module => ({ default: module.PeriodSelectors })));
@@ -73,6 +74,7 @@ export const start = (containerElement: HTMLElement): void => {
     // back to these components.
     // LayersSelector displays the configuration button and manages the canvas overlay.
     return <>
+      <style>{ css }</style>
       <span style={{ position: 'absolute', top: 0, left: 0, 'z-index': 200 /* must be above the “period selector” */ }}>
         <Burger domain={props.domain} />
       </span>

--- a/frontend/src/LayersSelector.tsx
+++ b/frontend/src/LayersSelector.tsx
@@ -46,46 +46,27 @@ export const LayersSelector = (props: {
           key={ model => model }
         />
       </fieldset>
-      <fieldset style={ fieldsetPaddingStyle }>
-        <Switch>
-          <Match when={ state.model === gfsModel }>
-            <legend>Initialization Time</legend>
-            <Select
-              title="Initialization time of the forecast run"
-              options={
-                props.domain.gfsRuns.map(gfsRun => {
-                  const initTimeString =
-                    showDate(
-                      gfsRun.init,
-                      { showWeekDay: true, timeZone: props.domain.timeZone() }
-                    );
-                  return [initTimeString, gfsRun]
-                })
-              }
-              selectedOption={ state.forecastMetadata }
-              onChange={ forecastMetadata => props.domain.setForecastMetadata(forecastMetadata) }
-              key={ forecastMetadata => forecastMetadata.initS }
-            />
-          </Match>
-          <Match when={ state.model === wrfModel }>
-            <legend>Date</legend>
-            <Select
-              title="Forecast date"
-              options={
-                props.domain.wrfRuns.map(wrfRun =>
-                  [
-                    showDate(wrfRun.firstTimeStep, { showWeekDay: true, timeZone: props.domain.timeZone() }),
-                    wrfRun
-                  ]
-                )
-              }
-              selectedOption={ state.forecastMetadata }
-              onChange={ value => props.domain.setForecastMetadata(value) }
-              key={ forecastMetadata => forecastMetadata.initS }
-            />
-          </Match>
-        </Switch>
-      </fieldset>
+      <Show when={ state.model === gfsModel }>
+        <fieldset style={ fieldsetPaddingStyle }>
+          <legend>Initialization Time</legend>
+          <Select
+            title="Initialization time of the forecast run"
+            options={
+              props.domain.gfsRuns.map(gfsRun => {
+                const initTimeString =
+                  showDate(
+                    gfsRun.init,
+                    { showWeekDay: true, timeZone: props.domain.timeZone() }
+                  );
+                return [initTimeString, gfsRun]
+              })
+            }
+            selectedOption={ state.forecastMetadata }
+            onChange={ forecastMetadata => props.domain.setForecastMetadata(forecastMetadata) }
+            key={ forecastMetadata => forecastMetadata.initS }
+          />
+        </fieldset>
+      </Show>
       <fieldset style={ fieldsetPaddingStyle }>
         <legend>Zone</legend>
           <Select

--- a/frontend/src/css-hooks.ts
+++ b/frontend/src/css-hooks.ts
@@ -1,0 +1,6 @@
+import { createHooks, recommended } from "@css-hooks/solid";
+
+const [css, hooks] = createHooks(recommended);
+
+export default hooks;
+export { css }

--- a/frontend/src/data/ForecastMetadata.ts
+++ b/frontend/src/data/ForecastMetadata.ts
@@ -159,7 +159,7 @@ const fetchPreviousRuns = async (model: Model, oldestForecastInitDate: Date, fir
 }
 
 // We show three forecast periods per day: morning, noon, and afternoon
-export const periodsPerDay = 3;
+const periodsPerDay = 3;
 
 // TODO Return an array containing an array for each day instead of a flat array
 export const forecastOffsets = (gfsRunDateTime: Date, firstPeriodOffset: number, forecastMetadata: ForecastMetadata): Array<[number, Date]> => {

--- a/frontend/src/shared.ts
+++ b/frontend/src/shared.ts
@@ -2,15 +2,15 @@
 
 import {type Model} from "./State";
 
-export const showDate = (date: Date, options: { showWeekDay?: boolean, timeZone: string | undefined }): string => {
+export const showDate = (date: Date, options: { showWeekDay?: boolean, timeZone?: string, showHour?: boolean }): string => {
   const formattedDate = date.toLocaleString(
     undefined,
     {
-      weekday: (options && options.showWeekDay && 'short') || undefined,
+      weekday: (options.showWeekDay && 'short') || undefined,
       month: 'short',
       day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
+      hour: (options.showHour !== undefined) ? (options.showHour ? '2-digit' : undefined) : '2-digit',
+      minute: (options.showHour !== undefined) ? (options.showHour ? '2-digit' : undefined) : '2-digit',
       hour12: false,
       timeZone: options.timeZone
     }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1429,6 +1429,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@css-hooks/core@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@css-hooks/core@npm:1.2.1"
+  checksum: 769a1aa1cc26f60921e92325a1074e571b04251c3d5700c2251adf1a0fb9c4b52f83f9a1c5373271ea203d9720f5e3c05f8e67584ef9f24a8ff6b3b3fbbbfa3b
+  languageName: node
+  linkType: hard
+
+"@css-hooks/solid@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@css-hooks/solid@npm:1.2.1"
+  dependencies:
+    "@css-hooks/core": ^1.2.1
+    ts-toolbelt: ^9.6.0
+  peerDependencies:
+    solid-js: ">=1.0.0 <2.0.0"
+  checksum: 53619d5a869ef04319937652e989288d5dd194ec4802b5840c764f104ab630cc186a658d2997e22134840f7c51e544bf3f5c268c21fa71248c6d62619702786b
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.16.17":
   version: 0.16.17
   resolution: "@esbuild/android-arm64@npm:0.16.17"
@@ -4444,6 +4463,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "soaringmeteo-v2@workspace:."
   dependencies:
+    "@css-hooks/solid": 1.2.1
     "@types/proj4": 2.5.4
     ol: 8.1.0
     proj4: 2.9.2
@@ -4759,6 +4779,13 @@ __metadata:
   dependencies:
     punycode: ^2.1.0
   checksum: 96d4ed46bc161db75dbf9247a236ea0bfcaf5758baae6749e92afab0bc5a09cb59af21788ede7e55080f2bf02dce3e4a8f2a484cc45164e29f4b5e68f7cbcc1a
+  languageName: node
+  linkType: hard
+
+"ts-toolbelt@npm:^9.6.0":
+  version: 9.6.0
+  resolution: "ts-toolbelt@npm:9.6.0"
+  checksum: 9f35fd95d895a5d32ea9fd2e532a695b0bae6cbff6832b77292efa188a0ed1ed6e54f63f74a8920390f3d909a7a3adb20a144686372a8e78b420246a9bd3d58a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add back the “-24” and “+24” buttons for the WRF model, and also show a date selector:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/d841237b-37b0-4ce5-a9ca-e4bcb7df069a)
