### PR TITLE
Don’t show the location details in a popup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,8 +77,14 @@ export const start = (containerElement: HTMLElement): void => {
       </span>
       <PeriodSelectors domain={props.domain} locationClicks={mapHooks.locationClicks} />
       <LayerKeys domain={props.domain} />
-      <span style={{ position: 'absolute', right: '.5em', bottom: '5em', 'text-align': 'right' }}>
-        <Help domain={props.domain} />
+      <span
+        style={{
+          position: 'absolute',
+          right: '.5rem',
+          bottom: '5rem',
+        }}
+      >
+        <Help domain={props.domain} overMap={true} />
       </span>
     </>
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,7 +81,7 @@ export const start = (containerElement: HTMLElement): void => {
         style={{
           position: 'absolute',
           right: '.5rem',
-          bottom: '5rem',
+          bottom: '.5rem',
         }}
       >
         <Help domain={props.domain} overMap={true} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,8 +60,7 @@ export const start = (containerElement: HTMLElement): void => {
     createEffect(() => {
       const detailedView = props.domain.state.detailedView;
       if (detailedView !== undefined) {
-        const selectedLocation = detailedView[0];
-        mapHooks.showMarker(selectedLocation.latitude, selectedLocation.longitude);
+        mapHooks.showMarker(detailedView.latitude, detailedView.longitude);
       } else {
         mapHooks.hideMarker();
       }
@@ -76,15 +75,8 @@ export const start = (containerElement: HTMLElement): void => {
       <span style={{ position: 'absolute', top: 0, left: 0, 'z-index': 200 /* must be above the “period selector” */ }}>
         <Burger domain={props.domain} />
       </span>
-      <PeriodSelectors
-        domain={props.domain}
-      />
-      <LayerKeys
-        popupRequest={mapHooks.popupRequest}
-        openLocationDetailsPopup={mapHooks.openPopup}
-        closeLocationDetailsPopup={mapHooks.closePopup}
-        domain={props.domain}
-      />
+      <PeriodSelectors domain={props.domain} locationClicks={mapHooks.locationClicks} />
+      <LayerKeys domain={props.domain} />
       <span style={{ position: 'absolute', right: '.5em', bottom: '5em', 'text-align': 'right' }}>
         <Help domain={props.domain} />
       </span>

--- a/frontend/src/Burger.tsx
+++ b/frontend/src/Burger.tsx
@@ -11,6 +11,7 @@ import { surfaceOverMap } from "./styles/Styles";
 import { Settings } from "./Settings";
 import {LayersSelector} from "./LayersSelector";
 import {OverlayContainer} from "./map/Overlay";
+import hooks from "./css-hooks";
 
 /**
  * Burger menu with links to the other parts of the website.
@@ -22,7 +23,6 @@ export const Burger = (props: {
   domain: Domain
 }): JSX.Element => {
 
-  const state = props.domain.state;
   const [expanded, setExpanded] = createSignal(false);
   const [areSettingsVisible, makeSettingsVisible] = createSignal(false);
 
@@ -91,13 +91,13 @@ export const Burger = (props: {
         </div>
         <div
           onClick={ () => setExpanded(false) }
-          style={{
-            ...surfaceOverMap,
+          style={hooks({
             ...closeButton,
             position: 'absolute',
             top: '3px',
-            right: '3px'
-          }}
+            right: '3px',
+            hover: { 'background-color': 'darkgray' }
+          })}
         >
           ⨯
         </div>
@@ -118,17 +118,14 @@ export const Burger = (props: {
       }
     </div>;
 
-  // TODO Show the menu also when there is no detailed view
-  return <Show when={ state.detailedView === undefined }>
-    <Show when={ expanded() } fallback={ menuBtn }>
-      <OverlayContainer handleClick={ () => setExpanded(false) }>
-        {options}
-      </OverlayContainer>
-      <Settings
-        isVisible={ areSettingsVisible() }
-        close={ () => makeSettingsVisible(false) }
-        domain={ props.domain }
-      />
-    </Show>
+  return <Show when={ expanded() } fallback={ menuBtn }>
+    <OverlayContainer handleClick={ () => setExpanded(false) }>
+      {options}
+    </OverlayContainer>
+    <Settings
+      isVisible={ areSettingsVisible() }
+      close={ () => makeSettingsVisible(false) }
+      domain={ props.domain }
+    />
   </Show>
 };

--- a/frontend/src/Burger.tsx
+++ b/frontend/src/Burger.tsx
@@ -69,7 +69,7 @@ export const Burger = (props: {
         cursor: 'auto', // otherwise we would inherit the value from the overlay container
         'font-size': '0.9rem',
         'max-height': '100%',
-        'overflow-y': 'scroll'
+        'overflow-y': 'auto'
       }}
       onClick={ e => e.stopPropagation() }
     >

--- a/frontend/src/DetailedView.tsx
+++ b/frontend/src/DetailedView.tsx
@@ -1,0 +1,24 @@
+import {LocationForecasts} from "./data/LocationForecasts";
+
+export type DetailedView = Meteogram | Sounding | Summary
+export type DetailedViewType = 'meteogram' | 'sounding' | 'summary'
+
+export type Meteogram = {
+  viewType: 'meteogram'
+  locationForecasts: LocationForecasts
+  latitude: number
+  longitude: number
+}
+
+export type Sounding = {
+  viewType: 'sounding'
+  locationForecasts: LocationForecasts
+  latitude: number
+  longitude: number
+}
+
+type Summary = {
+  viewType: 'summary'
+  latitude: number
+  longitude: number
+}

--- a/frontend/src/LayerKeys.tsx
+++ b/frontend/src/LayerKeys.tsx
@@ -1,109 +1,20 @@
 import {Domain} from "./State";
-import {Accessor, createEffect, createResource, JSX, Show} from "solid-js";
-import {toLonLat} from "ol/proj";
-import {surfaceOverMap} from "./styles/Styles";
-import {showCoordinates, showDate} from "./shared";
-import {MapBrowserEvent} from "ol";
+import {JSX} from "solid-js";
 
 export const LayerKeys = (props: {
   domain: Domain
-  popupRequest: Accessor<undefined | MapBrowserEvent<any>>
-  openLocationDetailsPopup: (latitude: number, longitude: number, content: HTMLElement) => void
-  closeLocationDetailsPopup: () => void
 }): JSX.Element => {
   const primaryLayerComponents = () => props.domain.primaryLayerReactiveComponents();
-  const windLayerComponents    = () => props.domain.windLayerReactiveComponents();
 
-  const layerKeyEl =
-    <div style={{
+  return <div style={{
     position: 'absolute',
-      bottom: '40px',
-      left: '5px',
-      'background-color': 'rgba(255, 255,  255, 0.5',
-      'font-size': '11px',
-      'padding': '5px',
-      'text-align': 'center'
+    bottom: '45px',
+    left: '5px',
+    'background-color': 'rgba(255, 255,  255, 0.5',
+    'font-size': '11px',
+    'padding': '5px',
+    'text-align': 'center'
   }}>
     {primaryLayerComponents().mapKey}
-  </div>;
-
-  // Show a popup with a summary when the user clicks on the map (TODO move to another file)
-  createEffect(() => {
-    const event = props.popupRequest();
-    if (event === undefined) {
-      return
-    }
-
-    const state = props.domain.state;
-    const [eventLng, eventLat] = toLonLat(event.coordinate);
-    const maybePoint =
-      state.forecastMetadata.closestPoint(state.zone, eventLng, eventLat);
-    if (maybePoint === undefined) {
-      return
-    }
-
-    const [longitude, latitude] =
-      state.forecastMetadata.toLonLat(state.zone, maybePoint);
-
-    const summaryPromise =
-      state.windLayerEnabled ?
-        Promise.all([
-          primaryLayerComponents().summarizer().summary(latitude, longitude),
-          windLayerComponents().summarizer().summary(latitude, longitude)
-        ])
-          .then(([primarySummary, windSummary]) => primarySummary?.concat(windSummary || [])) :
-        primaryLayerComponents().summarizer().summary(latitude, longitude);
-    const [summaryResource] =
-      createResource(() => summaryPromise.then(summary =>
-        summary !== undefined && summary.length !== 0 ? summary : undefined
-      ));
-    const content =
-      <div style={{ ...surfaceOverMap, background: 'white', padding: '.7em', 'font-size': '0.8125rem', 'text-align': 'left', 'border-radius': '5px' }}>
-    <span
-      style={{ position: 'absolute', top: '2px', right: '8px', cursor: 'pointer', 'font-weight': 'bold' }}
-    onClick={ () => props.closeLocationDetailsPopup() }
-    title="Close"
-      >
-          ×
-        </span>
-        <div>Grid point: { showCoordinates(longitude, latitude, props.domain.state.model) }</div>
-    <div>Forecast for {showDate(state.forecastMetadata.dateAtHourOffset(state.hourOffset), { showWeekDay: true, timeZone: props.domain.timeZone() })}</div>
-    <Show when={ summaryResource() }>
-      { summary => table(summary) }
-    </Show>
-    <div style={{ display: 'flex', 'align-items': 'center', 'justify-content': 'space-around' }}>
-    <button
-      onClick={ () => props.domain.showLocationForecast(eventLat, eventLng, 'meteogram') }
-    title="Meteogram for this location"
-      >
-      Meteogram
-      </button>
-      <button
-    onClick={ () => props.domain.showLocationForecast(eventLat, eventLng, 'sounding') }
-    title="Sounding for this time and location"
-      >
-      Sounding
-      </button>
-      </div>
-      </div> as HTMLElement;
-    props.openLocationDetailsPopup(latitude, longitude, content);
-  });
-
-  return layerKeyEl
-};
-
-const table = (data: Array<[string, JSX.Element]>): JSX.Element => {
-  const rows =
-    data.map(([label, value]) => {
-      return <tr><th>{label}:</th><td>{value}</td></tr>
-    });
-  if (rows.length === 0) {
-    return <div></div>
-  } else {
-    return <table>
-      <tbody>
-      { rows }
-      </tbody>
-    </table>;
-  }
+  </div>
 };

--- a/frontend/src/LayerKeys.tsx
+++ b/frontend/src/LayerKeys.tsx
@@ -8,8 +8,8 @@ export const LayerKeys = (props: {
 
   return <div style={{
     position: 'absolute',
-    bottom: '45px',
-    left: '5px',
+    bottom: '3rem',
+    right: '.5rem',
     'background-color': 'rgba(255, 255,  255, 0.5',
     'font-size': '11px',
     'padding': '5px',

--- a/frontend/src/LocationDetails.tsx
+++ b/frontend/src/LocationDetails.tsx
@@ -6,7 +6,8 @@ import {toLonLat} from "ol/proj";
 import {MapBrowserEvent} from "ol";
 import {Meteogram, Sounding} from "./DetailedView";
 import {Help} from "./help/Help";
-import {buttonStyle, surfaceOverMap} from "./styles/Styles";
+import {buttonStyle, closeButton, surfaceOverMap} from "./styles/Styles";
+import hooks from "./css-hooks";
 
 /**
  * Box showing the forecast details (summary, meteogram, or sounding) for the selected location.
@@ -44,7 +45,9 @@ export const LocationDetails = (props: {
           'display': 'inline-block',
           'background-color': 'white',
           'border-top': '1px solid darkgray',
-          padding: '.35em'
+          padding: '.35em',
+          'max-width': '100vw',
+          'box-sizing': 'border-box'
         }}
       >
         <Show
@@ -59,8 +62,14 @@ export const LocationDetails = (props: {
           </div>
         </Show>
 
-        {/* FIXME deal with width overflow */}
-        <div style={{ 'width': '22em',  display: 'flex', 'align-items': 'center', 'justify-content': 'space-around' }}>
+        <div
+          style={{
+            display: 'flex',
+            'flex-wrap': 'wrap',
+            'align-items': 'center',
+            'column-gap': '.3em'
+          }}
+        >
           <span
             style={{ ...buttonStyle, ...(detailedView.viewType === 'summary' ? { 'background-color': 'lightgray' } : {}) }}
             title="Summary of the forecast for this location"
@@ -85,7 +94,20 @@ export const LocationDetails = (props: {
             Sounding
           </span>
 
-          <Help domain={ props.domain } />
+          <Help domain={ props.domain } overMap={ false } />
+
+          <div
+            style={hooks({
+              ...closeButton,
+              'flex-shrink': 0,
+              'border': '1px solid lightgray',
+              hover: { 'background-color': 'lightgray' }
+            })}
+            title='Hide'
+            onClick={ () => props.domain.hideLocationForecast() }
+          >
+            ⨯
+          </div>
         </div>
       </div>
     }

--- a/frontend/src/LocationDetails.tsx
+++ b/frontend/src/LocationDetails.tsx
@@ -1,0 +1,159 @@
+import {Accessor, createEffect, createResource, JSX, on, Show} from "solid-js";
+import {showCoordinates, showDate} from "./shared";
+import {Domain} from "./State";
+import {LocationForecasts} from "./data/LocationForecasts";
+import {toLonLat} from "ol/proj";
+import {MapBrowserEvent} from "ol";
+import {Meteogram, Sounding} from "./DetailedView";
+import {Help} from "./help/Help";
+import {buttonStyle, surfaceOverMap} from "./styles/Styles";
+
+/**
+ * Box showing the forecast details (summary, meteogram, or sounding) for the selected location.
+ */
+export const LocationDetails = (props: {
+  locationClicks: Accessor<MapBrowserEvent<any> | undefined>
+  domain: Domain
+}): JSX.Element => {
+
+  // Open the detailed view when the users click on the map
+  createEffect(on(props.locationClicks, (event) => {
+    if (event === undefined) {
+      return
+    }
+    const [eventLng, eventLat] = toLonLat(event.coordinate);
+    const maybePoint =
+      props.domain.state.forecastMetadata.closestPoint(props.domain.state.zone, eventLng, eventLat);
+    if (maybePoint === undefined) {
+      return
+    }
+    const [longitude, latitude] =
+      props.domain.state.forecastMetadata.toLonLat(props.domain.state.zone, maybePoint);
+
+    const detailedViewType =
+      props.domain.state.detailedView?.viewType || 'summary'
+    props.domain.showLocationForecast(latitude, longitude, detailedViewType);
+  }));
+
+  return <Show when={ props.domain.state.detailedView }>
+    { detailedView =>
+      <div
+        style={{
+          ...surfaceOverMap,
+          'border-radius': '0 0 3px 0',
+          'display': 'inline-block',
+          'background-color': 'white',
+          'border-top': '1px solid darkgray',
+          padding: '.35em'
+        }}
+      >
+        <Show
+          when={ detailedView.viewType !== 'summary' /* The summary view shows the location by itself */ }
+          fallback={ <LocationSummary domain={props.domain} latitude={detailedView.latitude} longitude={detailedView.longitude} /> }
+        >
+          <div>
+            Location: { showCoordinates(detailedView.longitude, detailedView.latitude, props.domain.state.model) }, { (detailedView as Meteogram | Sounding).locationForecasts.elevation }m.
+            <Show when={ detailedView.viewType === 'sounding' }>
+              &nbsp;Time: { showDate(props.domain.state.forecastMetadata.dateAtHourOffset(props.domain.state.hourOffset), { showWeekDay: true, timeZone: props.domain.timeZone() }) }.
+            </Show>
+          </div>
+        </Show>
+
+        {/* FIXME deal with width overflow */}
+        <div style={{ 'width': '22em',  display: 'flex', 'align-items': 'center', 'justify-content': 'space-around' }}>
+          <span
+            style={{ ...buttonStyle, ...(detailedView.viewType === 'summary' ? { 'background-color': 'lightgray' } : {}) }}
+            title="Summary of the forecast for this location"
+            onClick={ () => props.domain.showLocationForecast(detailedView.latitude, detailedView.longitude, 'summary') }
+          >
+            Summary
+          </span>
+
+          <span
+            style={{ ...buttonStyle, ...(detailedView.viewType === 'meteogram' ? { 'background-color': 'lightgray' } : {}) }}
+            title="Meteogram for this location"
+            onClick={ () => props.domain.showLocationForecast(detailedView.latitude, detailedView.longitude, 'meteogram') }
+          >
+            Meteogram
+          </span>
+
+          <span
+            style={{ ...buttonStyle, ...(detailedView.viewType === 'sounding' ? { 'background-color': 'lightgray' } : {}) }}
+            title="Sounding for this time and location"
+            onClick={ () => props.domain.showLocationForecast(detailedView.latitude, detailedView.longitude, 'sounding') }
+          >
+            Sounding
+          </span>
+
+          <Help domain={ props.domain } />
+        </div>
+      </div>
+    }
+  </Show>
+
+};
+
+/** Forecast summary (wind speed, thermal velocity, etc.) at the selected location */
+const LocationSummary = (props: {
+  domain: Domain
+  latitude: number
+  longitude: number
+}): JSX.Element => {
+    const [resource] = createResource(
+      () => ({
+        windLayerEnabled: props.domain.state.windLayerEnabled,
+        primaryLayerSummarizer: props.domain.primaryLayerReactiveComponents().summarizer(),
+        windLayerSummarizer: props.domain.windLayerReactiveComponents().summarizer(),
+      }),
+      ({ windLayerEnabled, primaryLayerSummarizer, windLayerSummarizer }) => {
+        if (windLayerEnabled) {
+          return Promise.all([
+            primaryLayerSummarizer.summary(props.latitude, props.longitude),
+            windLayerSummarizer.summary(props.latitude, props.longitude)
+          ])
+            .then<[LocationForecasts, Array<[string, JSX.Element]> | undefined] | undefined>(([primarySummary, windSummary]) =>
+              (primarySummary === undefined || windSummary === undefined) ?
+                undefined :
+                [primarySummary[0], primarySummary[1]?.concat(windSummary[1] || [])]
+            )
+        } else {
+          return primaryLayerSummarizer.summary(props.latitude, props.longitude)
+        }
+      }
+    );
+    const summaryResource = () => {
+      const result: [LocationForecasts, Array<[string, JSX.Element]> | undefined] | undefined = resource();
+      if (result !== undefined && result[1] !== undefined && result[1].length !== 0) {
+        return result[1]
+      } else {
+        return undefined
+      }
+    };
+    return <>
+      <div>
+        Location: { showCoordinates(props.longitude, props.latitude, props.domain.state.model) }
+        <Show when={resource()}>
+          { ([locationForecasts]) => <>, {locationForecasts.elevation}m</> }
+        </Show>.
+      </div>
+      <Show when={summaryResource()}>
+        { summary => table(summary)}
+      </Show>
+    </>;
+};
+
+const table = (data: Array<[string, JSX.Element]>): JSX.Element => {
+  const rows =
+    data.map(([label, value]) => {
+      return <tr><th>{label}:</th><td>{value}</td></tr>
+    });
+  if (rows.length === 0) {
+    return <div></div>
+  } else {
+    return <table>
+      <tbody>
+      { rows }
+      </tbody>
+    </table>;
+  }
+};

--- a/frontend/src/LocationDetails.tsx
+++ b/frontend/src/LocationDetails.tsx
@@ -47,7 +47,8 @@ export const LocationDetails = (props: {
           'border-top': '1px solid darkgray',
           padding: '.35em',
           'max-width': '100vw',
-          'box-sizing': 'border-box'
+          'box-sizing': 'border-box',
+          'user-select': 'text'
         }}
       >
         <Show
@@ -55,9 +56,9 @@ export const LocationDetails = (props: {
           fallback={ <LocationSummary domain={props.domain} latitude={detailedView.latitude} longitude={detailedView.longitude} /> }
         >
           <div>
-            Location: { showCoordinates(detailedView.longitude, detailedView.latitude, props.domain.state.model) }, { (detailedView as Meteogram | Sounding).locationForecasts.elevation }m.
+            { showCoordinates(detailedView.longitude, detailedView.latitude, props.domain.state.model) }, { (detailedView as Meteogram | Sounding).locationForecasts.elevation }m.
             <Show when={ detailedView.viewType === 'sounding' }>
-              &nbsp;Time: { showDate(props.domain.state.forecastMetadata.dateAtHourOffset(props.domain.state.hourOffset), { showWeekDay: true, timeZone: props.domain.timeZone() }) }.
+              &nbsp;{ showDate(props.domain.state.forecastMetadata.dateAtHourOffset(props.domain.state.hourOffset), { showWeekDay: true, timeZone: props.domain.timeZone() }) }.
             </Show>
           </div>
         </Show>
@@ -153,7 +154,7 @@ const LocationSummary = (props: {
     };
     return <>
       <div>
-        Location: { showCoordinates(props.longitude, props.latitude, props.domain.state.model) }
+        { showCoordinates(props.longitude, props.latitude, props.domain.state.model) }
         <Show when={resource()}>
           { ([locationForecasts]) => <>, {locationForecasts.elevation}m</> }
         </Show>.

--- a/frontend/src/PeriodSelector.tsx
+++ b/frontend/src/PeriodSelector.tsx
@@ -119,7 +119,7 @@ const PeriodSelector = (props: {
 
   const length = () => periodSelectorsByDay().reduce((n, ss) => n + ss[0].length, 0);
   const scrollablePeriodSelector =
-    <div style={{ ...surfaceOverMap, 'border-radius': '0 0 3px 0', 'overflow-x': 'auto', 'background-color': 'white' }}>
+    <div style={{ ...surfaceOverMap, 'border-radius': '0 0 3px 0', 'overflow-x': 'auto', 'background-color': 'white', 'margin-left': `${marginLeft}px` }}>
       <div style={{ 'min-width': `${length() * meteogramColumnWidth + keyWidth}px` }}>
         <div>{periodSelectors}</div>
         {props.detailedView}
@@ -316,29 +316,11 @@ export const PeriodSelectors = (props: {
       domain={ props.domain }
     />;
 
-  const hideDetailedViewBtn =
-    <div
-      style={{
-        ...closeButton,
-        ...surfaceOverMap,
-        'margin-right': `${marginLeft - closeButtonSize}px`,
-        'flex-shrink': 0,
-        visibility: (state.detailedView !== undefined) ? 'visible' : 'hidden'
-      }}
-      title='Hide'
-      onClick={() => props.domain.hideLocationForecast() }
-    >
-      ⨯
-    </div>;
-
   // Period selector and close button for the meteogram
   const periodSelectorContainer =
     <span style={{ position: 'absolute', top: 0, left: 0, 'z-index': 100, 'max-width': '100%', 'user-select': 'none', cursor: 'default', 'font-size': '0.8125rem' }}>
+      {periodSelectorEl}
       {detailedViewKeyEl}
-      <div style={{ display: 'flex', 'align-items': 'flex-start' }}>
-        {hideDetailedViewBtn}
-        {periodSelectorEl}
-      </div>
       <LocationDetails locationClicks={props.locationClicks} domain={props.domain} /> {/* TODO Move out of PeriodSelector */}
     </span>;
 

--- a/frontend/src/PeriodSelector.tsx
+++ b/frontend/src/PeriodSelector.tsx
@@ -5,8 +5,6 @@ import {showDate} from './shared';
 import {type Domain, gfsModel, wrfModel} from './State';
 import {
   buttonStyle,
-  closeButton,
-  closeButtonSize,
   keyWidth,
   meteogramColumnWidth,
   periodSelectorHeight,
@@ -110,7 +108,9 @@ const PeriodSelector = (props: {
                 '\xa0'
             }
           </div>;
-        return <div style={{ display: 'inline-block' }}>
+        return <div
+          style={{ ...surfaceOverMap, 'background-color': 'white', display: 'inline-block' }}
+        >
           {dayEl}
           <div style={{ 'text-align': 'right' }}>{periods.map(tuple => tuple[0])}</div>
         </div>;
@@ -119,9 +119,17 @@ const PeriodSelector = (props: {
 
   const length = () => periodSelectorsByDay().reduce((n, ss) => n + ss[0].length, 0);
   const scrollablePeriodSelector =
-    <div style={{ ...surfaceOverMap, 'border-radius': '0 0 3px 0', 'overflow-x': 'auto', 'background-color': 'white', 'margin-left': `${marginLeft}px` }}>
+    <div
+      style={{
+        'border-radius': '0 0 3px 0',
+        'overflow-x': 'auto',
+        'margin-left': `${marginLeft}px`,
+        'user-select': 'none',
+        cursor: 'default'
+    }}
+    >
       <div style={{ 'min-width': `${length() * meteogramColumnWidth + keyWidth}px` }}>
-        <div>{periodSelectors}</div>
+        <div>{periodSelectors()}</div>
         {props.detailedView}
       </div>
     </div>;
@@ -149,7 +157,13 @@ const detailedView = (props: { domain: Domain }): (() => { key: JSX.Element, vie
     } else {
       if (detailedView.viewType === 'meteogram') {
         import('./diagrams/Meteogram').then(module => {
-          set(module.meteogram(detailedView.locationForecasts, state));
+          const { key, view } = module.meteogram(detailedView.locationForecasts, state);
+          set({
+            key,
+            view: <div style={{ ...surfaceOverMap, 'background-color': 'white' }}>
+              {view}
+            </div>
+          });
         });
       } else if (detailedView.viewType === 'sounding') {
         const forecast = detailedView.locationForecasts.atHourOffset(state.hourOffset);
@@ -318,11 +332,11 @@ export const PeriodSelectors = (props: {
 
   // Period selector and close button for the meteogram
   const periodSelectorContainer =
-    <span style={{ position: 'absolute', top: 0, left: 0, 'z-index': 100, 'max-width': '100%', 'user-select': 'none', cursor: 'default', 'font-size': '0.8125rem' }}>
+    <div style={{ position: 'absolute', top: 0, left: 0, 'z-index': 100, 'max-width': '100%', 'font-size': '0.8125rem' }}>
       {periodSelectorEl}
       {detailedViewKeyEl}
       <LocationDetails locationClicks={props.locationClicks} domain={props.domain} /> {/* TODO Move out of PeriodSelector */}
-    </span>;
+    </div>;
 
   // Current period
   const currentDayContainer =

--- a/frontend/src/data/ForecastMetadata.ts
+++ b/frontend/src/data/ForecastMetadata.ts
@@ -173,3 +173,11 @@ export const forecastOffsets = (gfsRunDateTime: Date, firstPeriodOffset: number,
       return [gfsOffset, date]
     })
 };
+
+export const wrfForecastOffsets = (wrfRun: ForecastMetadata): Array<[number, Date]> => {
+  return Array.from({ length: wrfRun.latest + 1 }).map((_, i) => {
+    const date = new Date(wrfRun.firstTimeStep);
+    date.setUTCHours(date.getUTCHours() + i);
+    return [i, date]
+  });
+};

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -1,5 +1,5 @@
 import { createSignal, JSX, lazy, Match, Show, Switch } from 'solid-js'
-import { bottomButtonsSize, keyWidth, soundingWidth, surfaceOverMap } from '../styles/Styles';
+import {bottomButtonsSize, keyWidth, meteogramColumnWidth, soundingWidth, surfaceOverMap} from '../styles/Styles';
 import * as fakeData from './data';
 import { showDate, xcFlyingPotentialLayerName, inversionStyle } from '../shared';
 import { type Domain } from '../State';
@@ -118,7 +118,7 @@ const MeteogramHelp = (props: { domain: Domain }): JSX.Element => <>
     Meteograms show the weather forecast for the selected location over time. Here is an
     example of three days meteogram that we made up for documentation purpose:
   </p>
-  <div style={{ float: 'left', 'margin-right': '1em' }}>
+  <div style={{ float: 'left', 'margin-right': '1em', 'min-width': `${ keyWidth * 2 + meteogramColumnWidth * 3 * 3 }px` }}>
     { lazyMeteogram({ domain: props.domain }) }
   </div>
   <p>

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -6,14 +6,14 @@ import { type Domain } from '../State';
 import { Overlay } from '../map/Overlay';
 import hooks from "../css-hooks";
 
-export const Help = (props: { domain: Domain }): JSX.Element => {
+export const Help = (props: { domain: Domain, overMap: boolean }): JSX.Element => {
 
   const state = props.domain.state;
   const [isVisible, makeVisible] = createSignal(false);
 
   const expandButton =
     <div style={hooks({
-        ...surfaceOverMap,
+        ...(props.overMap ? surfaceOverMap : {}),
         'cursor': 'pointer',
         display: 'inline-block',
         width: `${bottomButtonsSize}px`,
@@ -33,7 +33,7 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
       ?
     </div>;
 
-  const help = <span
+  return <span
     style={{
       display: 'block',
       margin: '3px'
@@ -59,9 +59,7 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
         </Switch>
       </span>
     </Overlay>
-  </span> as HTMLElement;
-
-  return help
+  </span>;
 };
 
 const MapHelp = (props: { domain: Domain }): JSX.Element => {

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -15,6 +15,7 @@ export const Help = (props: { domain: Domain, overMap: boolean }): JSX.Element =
     <div style={hooks({
         ...(props.overMap ? surfaceOverMap : {}),
         'cursor': 'pointer',
+        'user-select': 'none',
         display: 'inline-block',
         width: `${bottomButtonsSize}px`,
         height: `${bottomButtonsSize}px`,
@@ -72,16 +73,19 @@ const MapHelp = (props: { domain: Domain }): JSX.Element => {
       a <a href='https://soaringmeteo.org/don.html'>donation</a> to help us cover our cost.
     </p>
     <p>
-      You are looking at the weather forecast for { showDate(state.forecastMetadata.dateAtHourOffset(state.hourOffset), { timeZone: props.domain.timeZone() }) },
+      What you see is the weather forecast for { showDate(state.forecastMetadata.dateAtHourOffset(state.hourOffset), { timeZone: props.domain.timeZone() }) },
       from the model { props.domain.modelName() } initialized at { showDate(state.forecastMetadata.init, { timeZone: props.domain.timeZone() }) }.
     </p>
     <p>
-      Select the information to display on the map, or the zone of the world to cover,
-      by clicking on the “layers” button at the bottom right of the screen.
+      Use the top-left menu to select which information to display on the map (cross-country flying potential,
+      thermal velocity, wind speed and direction, etc.). You can also select a different weather forecast model,
+      or a different area of the world.
     </p>
-    <p>
-      Currently, you see the <strong>{ state.primaryLayer.title }</strong>.
-    </p>
+    <Show when={ state.primaryLayerEnabled }>
+      <p>
+        Currently, you see the <strong>{ state.primaryLayer.title }</strong>.
+      </p>
+    </Show>
     { props.domain.primaryLayerReactiveComponents().help }
     <Show when={ state.windLayerEnabled }>
       <p>

--- a/frontend/src/help/Help.tsx
+++ b/frontend/src/help/Help.tsx
@@ -4,6 +4,7 @@ import * as fakeData from './data';
 import { showDate, xcFlyingPotentialLayerName, inversionStyle } from '../shared';
 import { type Domain } from '../State';
 import { Overlay } from '../map/Overlay';
+import hooks from "../css-hooks";
 
 export const Help = (props: { domain: Domain }): JSX.Element => {
 
@@ -11,7 +12,7 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
   const [isVisible, makeVisible] = createSignal(false);
 
   const expandButton =
-    <div style={{
+    <div style={hooks({
         ...surfaceOverMap,
         'cursor': 'pointer',
         display: 'inline-block',
@@ -21,8 +22,11 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
         'text-align': 'center',
         'font-size': '18px',
         'border-radius': `${bottomButtonsSize / 2}px`,
-        'background-color': 'white'
-      }}
+        'border': '1px solid lightgray',
+        'box-sizing': 'border-box',
+        'background-color': 'white',
+        hover: { 'background-color': 'lightgray' }
+      })}
       onClick={ () => makeVisible(true) }
       title="Help"
     >
@@ -43,13 +47,13 @@ export const Help = (props: { domain: Domain }): JSX.Element => {
     >
       <span style="text-align: left">
         <Switch>
-          <Match when={ state.detailedView === undefined }>
+          <Match when={ state.detailedView === undefined || state.detailedView.viewType === 'summary' }>
             <MapHelp domain={props.domain} />
           </Match>
-          <Match when={ state.detailedView !== undefined && state.detailedView[1] === 'meteogram' }>
+          <Match when={ state.detailedView !== undefined && state.detailedView.viewType === 'meteogram' }>
             <MeteogramHelp domain={props.domain} />
           </Match>
-          <Match when={ state.detailedView !== undefined && state.detailedView[1] === 'sounding' }>
+          <Match when={ state.detailedView !== undefined && state.detailedView.viewType === 'sounding' }>
             <SoundingHelp domain={props.domain} />
           </Match>
         </Switch>

--- a/frontend/src/layers/CumuliDepth.tsx
+++ b/frontend/src/layers/CumuliDepth.tsx
@@ -40,7 +40,7 @@ export const cumuliDepthLayer: Layer = {
         means no thermals or blue thermals. Deep cumulus clouds means there is
         risk of over-development.
       </p>
-      <p>The color scale is shown on the bottom left of the screen.</p>
+      <p>The color scale is shown on the bottom right of the screen.</p>
     </>;
 
     return {

--- a/frontend/src/layers/Layer.tsx
+++ b/frontend/src/layers/Layer.tsx
@@ -5,7 +5,7 @@ import {DetailedForecast, LocationForecasts} from "../data/LocationForecasts";
 
 type Summarizer = {
   /** Create a summary of the forecast data on the point (shown in popups) */
-  summary(lat: number, lng: number): Promise<Array<[string, JSX.Element]> | undefined>
+  summary(lat: number, lng: number): Promise<[LocationForecasts, Array<[string, JSX.Element]> | undefined] | undefined>
 }
 
 // Non-static parts of layers
@@ -66,13 +66,16 @@ export const colorScaleEl = (colorScale: ColorScale, format: (value: number) => 
       () => {}
     )();
     return {
-      async summary(lat: number, lng: number): Promise<Array<[string, JSX.Element]> | undefined> {
+      async summary(lat: number, lng: number): Promise<[LocationForecasts, Array<[string, JSX.Element]> | undefined] | undefined> {
         const locationForecasts = await props.forecastMetadata.fetchLocationForecasts(props.zone, lat, lng);
-        const detailedForecast = locationForecasts?.atHourOffset(props.hourOffset);
-        if (detailedForecast !== undefined) {
-          return summary(detailedForecast, locationForecasts as LocationForecasts)
-        } else {
+        if (locationForecasts === undefined) {
           return undefined
+        }
+        const detailedForecast = locationForecasts.atHourOffset(props.hourOffset);
+        if (detailedForecast === undefined) {
+          return [locationForecasts, undefined]
+        } else {
+          return [locationForecasts, summary(detailedForecast, locationForecasts)]
         }
       }
     }

--- a/frontend/src/layers/Rain.tsx
+++ b/frontend/src/layers/Rain.tsx
@@ -28,7 +28,7 @@ export const rainLayer: Layer = {
     return {
       summarizer,
       mapKey: colorScaleEl(rainColorScale, value => `${value} mm `),
-      help: <p>The color scale is shown on the bottom left of the screen.</p>
+      help: <p>The color scale is shown on the bottom right of the screen.</p>
     }
   }
 };

--- a/frontend/src/layers/SoaringLayerDepth.tsx
+++ b/frontend/src/layers/SoaringLayerDepth.tsx
@@ -37,7 +37,7 @@ export const soaringLayerDepthLayer: Layer = {
         boundary layer</a>, otherwise (if there are cumulus clouds) it stops at the cloud base.
       </p>
       <p>
-        The color scale is shown on the bottom left of the screen.
+        The color scale is shown on the bottom right of the screen.
       </p>
     </>;
 

--- a/frontend/src/layers/ThQ.tsx
+++ b/frontend/src/layers/ThQ.tsx
@@ -80,14 +80,13 @@ export const xcFlyingPotentialLayer: Layer = {
 
     const help = <>
       <p>
-        The XC flying potential index is a single indicator that takes into account
+        It indicates the potential for cross-country flying, from 0% (poor thermals,
+        or very strong wind) to 100% (strong, high thermals, weak wind). Look for white
+        or blue areas (the full color scale is shown on the bottom right of the screen).
+        The XC flying potential index takes into account
         the soaring layer depth, the sunshine, and the average wind speed within the
         boundary layer. Deep soaring layer, strong sunshine, and low wind speeds
         increase the value of this indicator.
-      </p>
-      <p>
-        The color scale is shown on the bottom left of the screen. Click to a location
-        on the map to get numerical data.
       </p>
     </>;
 

--- a/frontend/src/layers/ThermalVelocity.tsx
+++ b/frontend/src/layers/ThermalVelocity.tsx
@@ -35,7 +35,7 @@ export const thermalVelocityLayer: Layer = {
       mapKey: colorScaleEl(thermalVelocityColorScale, value => `${value} m/s `),
       help: <p>
         The thermal updraft velocity is estimated from the depth of the boundary
-        layer and the sunshine. The color scale is shown on the bottom left of the
+        layer and the sunshine. The color scale is shown on the bottom right of the
         screen.
       </p>
     }

--- a/frontend/src/layers/Wind.tsx
+++ b/frontend/src/layers/Wind.tsx
@@ -35,7 +35,7 @@ const windComponents = (
 export const boundaryLayerWindLayer: Layer = {
   key: 'boundary-layer-wind',
   name: 'Boundary Layer',
-  title: 'Average wind force and direction in the boundary layer',
+  title: 'Average wind speed and direction in the boundary layer',
   dataPath: 'wind-boundary-layer',
   reactiveComponents: windComponents(data => data.boundaryLayer.wind)
 };
@@ -43,7 +43,7 @@ export const boundaryLayerWindLayer: Layer = {
 export const surfaceWindLayer: Layer = {
   key: 'surface-wind',
   name: 'Surface',
-  title: 'Wind force and direction on the ground',
+  title: 'Wind speed and direction on the ground',
   dataPath: 'wind-surface',
   reactiveComponents: windComponents(data => data.surface.wind)
 };
@@ -51,7 +51,7 @@ export const surfaceWindLayer: Layer = {
 export const soaringLayerTopWindLayer: Layer = {
   key: 'soaring-layer-top-wind',
   name: 'Soaring Layer Top',
-  title: 'Wind force and direction at the top of the soaring layer',
+  title: 'Wind speed and direction at the top of the soaring layer',
   dataPath: 'wind-soaring-layer-top',
   reactiveComponents: windComponents(data => data.winds.soaringLayerTop)
 };
@@ -59,7 +59,7 @@ export const soaringLayerTopWindLayer: Layer = {
 export const _300MAGLWindLayer: Layer = {
   key: '300m-agl-wind',
   name: '300 m AGL',
-  title: 'Wind force and direction at 300 m above the ground level',
+  title: 'Wind speed and direction at 300 m above the ground level',
   dataPath: 'wind-300m-agl',
   reactiveComponents: windComponents(data => data.winds._300MAGL)
 };
@@ -67,7 +67,7 @@ export const _300MAGLWindLayer: Layer = {
 export const _2000MAMSLWindLayer: Layer = {
   key: '2000m-amsl-wind',
   name: '2000 m AMSL',
-  title: 'Wind force and direction at 2000 m above the mean sea level',
+  title: 'Wind speed and direction at 2000 m above the mean sea level',
   dataPath: 'wind-2000m-amsl',
   reactiveComponents: windComponents( data => data.winds._2000MAMSL)
 };
@@ -75,7 +75,7 @@ export const _2000MAMSLWindLayer: Layer = {
 export const _3000MAMSLWindLayer: Layer = {
   key: '3000m-amsl-wind',
   name: '3000 m AMSL',
-  title: 'Wind force and direction at 3000 m above the mean sea level',
+  title: 'Wind speed and direction at 3000 m above the mean sea level',
   dataPath: 'wind-3000m-amsl',
   reactiveComponents: windComponents(data => data.winds._3000MAMSL)
 };
@@ -83,7 +83,7 @@ export const _3000MAMSLWindLayer: Layer = {
 export const _4000MAMSLWindLayer: Layer = {
   key: '4000m-amsl-wind',
   name: '4000 m AMSL',
-  title: 'Wind force and direction at 4000 m above the mean sea level',
+  title: 'Wind speed and direction at 4000 m above the mean sea level',
   dataPath: 'wind-4000m-amsl',
   reactiveComponents: windComponents(data => data.winds._4000MAMSL)
 };

--- a/frontend/src/map/Map.ts
+++ b/frontend/src/map/Map.ts
@@ -2,7 +2,8 @@ import { Feature, Map, MapBrowserEvent, View } from 'ol';
 import { Tile as TileLayer, Image as ImageLayer, Vector as VectorLayer, VectorTile as VectorTileLayer } from 'ol/layer';
 import { ImageStatic, Vector as VectorSource, VectorTile as VectorTileSource, XYZ } from "ol/source";
 import { fromLonLat, get as getProjection, Projection, toLonLat } from "ol/proj";
-import { Rotate, ScaleLine, Zoom } from "ol/control";
+import { ScaleLine } from "ol/control";
+import { defaults as defaultInteractions } from "ol/interaction";
 import { Coordinate } from "ol/coordinate";
 import { Point } from 'ol/geom';
 import { GeoJSON } from "ol/format";
@@ -140,15 +141,14 @@ export const initializeMap = (element: HTMLElement): MapHooks => {
       zoom: zoom
     }),
     controls: [
-      new Zoom(),
-      new Rotate(),
       new ScaleLine({
         units: 'metric',
         bar: true,
         steps: 2,
         text: false
       })
-    ]
+    ],
+    interactions: defaultInteractions({ pinchRotate: false })
   });
 
   map.on('moveend', () => {

--- a/frontend/src/map/Overlay.tsx
+++ b/frontend/src/map/Overlay.tsx
@@ -10,9 +10,9 @@ export const OverlayContainer = (props: {
     style={{
       position: 'fixed',
       inset: '0',
-      'background-color': 'rgb(0, 0, 0, 0.25)',
+      'background-color': 'rgb(0, 0, 0, 0.20)',
+      'backdrop-filter': 'blur(1px)',
       cursor: 'pointer',
-      'backdrop-filter': 'blur(2px)',
       display: 'flex',
       'align-items': 'center',
       'justify-content': 'center',

--- a/frontend/src/styles/Styles.tsx
+++ b/frontend/src/styles/Styles.tsx
@@ -7,7 +7,7 @@ export const surfaceOverMap = {
 // size of the buttons at the bottom of the screen (info and help)
 export const bottomButtonsSize = 24;
 // size of the button used for closing panels
-export const closeButtonSize = 32;
+export const closeButtonSize = 24;
 // width of the left key shown on the diagrams
 export const keyWidth = 40;
 // width of the sounding diagrams
@@ -21,10 +21,8 @@ export const closeButton = {
   width: `${closeButtonSize}px`,
   height: `${closeButtonSize}px`,
   'line-height': `${closeButtonSize}px`,
-  color: 'white',
   display: 'inline-block',
   cursor: 'pointer',
-  'background-color': 'darkGray',
   'text-align': 'center',
   'border-radius': `${closeButtonSize / 2}px`,
   'font-size': '18px'

--- a/frontend/src/styles/Styles.tsx
+++ b/frontend/src/styles/Styles.tsx
@@ -11,9 +11,13 @@ export const closeButtonSize = 24;
 // width of the left key shown on the diagrams
 export const keyWidth = 40;
 // width of the sounding diagrams
-export const soundingWidth = 600;
+export const soundingWidth = Math.max(Math.min(600, document.documentElement.clientWidth - keyWidth), 250);
+
+// available height in the viewport for drawing the diagrams (sounding and meteogram)
+export const diagramsAvailableHeight = document.documentElement.clientHeight - 35 /* top time selector */ - 52 /* bottom time selector */ - 58 /* text information and help */ - 5;
+
 // height of the period selector shown at the top of the screen
-export const periodSelectorHeight = 35; // Day height + hour height + 2 (wtf)
+export const periodSelectorHeight = 13 /* day height */ + 22 /* hour height */;
 // width of one time period in meteograms
 export const meteogramColumnWidth = 37;
 
@@ -23,6 +27,7 @@ export const closeButton = {
   'line-height': `${closeButtonSize}px`,
   display: 'inline-block',
   cursor: 'pointer',
+  'user-select': 'none',
   'text-align': 'center',
   'border-radius': `${closeButtonSize / 2}px`,
   'font-size': '18px'
@@ -40,4 +45,4 @@ export const burgerOptionStyle = hooks({
 
 export const burgerBorderTopStyle = { 'border-top': '1px solid darkgray' };
 
-export const buttonStyle = hooks({ padding: '0.3em 0.4em', cursor: 'pointer', border: 'thin solid darkGray', 'box-sizing': 'border-box', hover: { 'background-color': 'lightGray' } });
+export const buttonStyle = hooks({ padding: '0.3em 0.4em', cursor: 'pointer', border: 'thin solid darkGray', 'box-sizing': 'border-box', 'user-select': 'none', hover: { 'background-color': 'lightGray' } });

--- a/frontend/src/styles/Styles.tsx
+++ b/frontend/src/styles/Styles.tsx
@@ -42,3 +42,4 @@ export const burgerOptionStyle = hooks({
 
 export const burgerBorderTopStyle = { 'border-top': '1px solid darkgray' };
 
+export const buttonStyle = hooks({ padding: '0.3em 0.4em', cursor: 'pointer', border: 'thin solid darkGray', 'box-sizing': 'border-box', hover: { 'background-color': 'lightGray' } });


### PR DESCRIPTION
This is a departure from the current user interface in soarWRF and soarGFS.

Instead of opening a popup when the user clicks on the map, we show the location details in a box on the side of the window. This resolves two issues:

- since there is no popup anymore, the users are not bothered by the popup if they want to click on point close to the one previously clicked (see the videos below)
- showing the meteograms or sounding diagrams of multiple locations is simpler as the users don’t need to click to “Meteogram” again and again for each location.

I think the resulting layout is still a bit weird (not everything is correctly aligned), and I know it does not work very well on small screens. I will work on that tomorrow.

Here is a video that shows the existing behavior and another video that shows the new behavior:

[existing behavior](https://github.com/soaringmeteo/soaringmeteo/assets/332812/e3eb0414-2b34-477e-b178-dee814229be0)
[new behavior](https://github.com/soaringmeteo/soaringmeteo/assets/332812/33d60815-7ebc-4d61-960a-2395e3eec121)

You can try it on [v2-dev](https://soarwrf1.soaringmeteo.org/v2-dev).