### PR TITLE
Make colors in legends look a bit more like the colors on the map

### DIFF
--- a/frontend/src/LayerKeys.tsx
+++ b/frontend/src/LayerKeys.tsx
@@ -11,9 +11,9 @@ export const LayerKeys = (props: {
       position: 'absolute',
       bottom: '3rem',
       right: '.5rem',
-      'background-color': 'rgba(255, 255,  255, 0.5',
+      'background-color': '#d6d6c5', // “neutral” color in the basemap
       'font-size': '11px',
-      'padding': '5px',
+      'padding': '4px',
       'text-align': 'center'
     }}>
       {primaryLayerComponents().mapKey}

--- a/frontend/src/layers/CumuliDepth.tsx
+++ b/frontend/src/layers/CumuliDepth.tsx
@@ -3,11 +3,11 @@ import {colorScaleEl, Layer, ReactiveComponents, summarizerFromLocationDetails} 
 import {ForecastMetadata, Zone} from "../data/ForecastMetadata";
 
 const cumuliDepthColorScale = new ColorScale([
-  [50,   new Color(0xff, 0xff, 0xff, 0)],
-  [400,  new Color(0xff, 0xff, 0xff, 0.25)],
-  [800,  new Color(0xff, 0xff, 0xff, 0.5)],
-  [1500, new Color(0xff, 0xff, 0x00, 0.5)],
-  [3000, new Color(0xff, 0x00, 0x00, 0.5)]
+  [50,   new Color(0xff, 0xff, 0xff, 0.0)],
+  [400,  new Color(0xff, 0xff, 0xff, 0.5)],
+  [800,  new Color(0xff, 0xff, 0xff, 1.0)],
+  [1500, new Color(0xff, 0xff, 0x00, 1.0)],
+  [3000, new Color(0xff, 0x00, 0x00, 1.0)]
 ]);
 
 export const cumuliDepthLayer: Layer = {

--- a/frontend/src/layers/Layer.tsx
+++ b/frontend/src/layers/Layer.tsx
@@ -42,7 +42,7 @@ export const colorScaleEl = (colorScale: ColorScale, format: (value: number) => 
   return <div style={{ width: `${length * 2 / 3}em`, 'padding-top': '0.3em' /* because text overflows */, margin: 'auto' }}>
   {
     colorsAndValues.map(([color, value]) =>
-      <div style={{ height: '2em', 'background-color': color.css(), position: 'relative' }}>
+      <div style={{ height: '2em', opacity: 0.7, 'background-color': color.css(), position: 'relative' }}>
         <span style={{ position: 'absolute', top: '-.6em', right: '0.5em', 'text-shadow': 'white 1px 1px 2px' }}>{value}</span>
       </div>
     )


### PR DESCRIPTION
Because the map overlays are a bit transparent, the colors seen in the overlay legend (bottom right of the screen) can look pretty different from those seen on the map overlays.

We apply some transparency to the colors shown in the legend as well to make them look more similar to the colors in the overlays.

Before:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/1b1c4fd5-5d52-43b5-8685-dc7e1fb5f542)

After:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/b95dc539-dbc4-465f-98c2-a468e68e2f26)

Also with clouds and rain. Before:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/428e09d2-b709-475e-be65-a96ac88bfac8)


After:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/65957e26-b8a4-4406-bddd-55c692235430)
