### PR TITLE
Use the MVT format for vector tiles instead of JSON

### DIFF
--- a/backend/build.sbt
+++ b/backend/build.sbt
@@ -20,6 +20,7 @@ val common =
         Dependencies.decline,
         // Image generation
         Dependencies.geotrellisRaster,
+        Dependencies.geotrellisVectorTile,
         // grib2 and NetCDF files manipulation
         "edu.ucar" % "grib" % "5.5.3",
         // Quantities

--- a/backend/common/src/main/scala/org/soaringmeteo/out/package.scala
+++ b/backend/common/src/main/scala/org/soaringmeteo/out/package.scala
@@ -8,7 +8,7 @@ package object out {
    * We need to bump this number everytime we introduce incompatibilities (e.g. adding a non-optional field).
    * Make sure to also bump the `formatVersion` in the frontend (see frontend/src/data/ForecastMetadata.ts).
    */
-  val formatVersion = 5
+  val formatVersion = 6
 
   /**
    * Delete the target directories older than the `oldestForecastToKeep`.

--- a/backend/project/Dependencies.scala
+++ b/backend/project/Dependencies.scala
@@ -16,7 +16,8 @@ object Dependencies {
   val decline = "com.monovore" %% "decline" % "2.4.1"
 
   // Raster images generation
-  val geotrellisRaster = "org.locationtech.geotrellis" %% "geotrellis-raster" % "3.7.0"
+  val geotrellisRaster     = "org.locationtech.geotrellis" %% "geotrellis-raster" % "3.7.1"
+  val geotrellisVectorTile = "org.locationtech.geotrellis" %% "geotrellis-vectortile" % "3.7.1"
 
   // Logging
   val logback = "ch.qos.logback" % "logback-classic" % "1.4.7"

--- a/frontend/src/data/ForecastMetadata.ts
+++ b/frontend/src/data/ForecastMetadata.ts
@@ -30,7 +30,7 @@ export type Zone = {
 }
 
 // Version of the forecast data format we consume (see backend/src/main/scala/org/soaringmeteo/package.scala)
-const formatVersion = 5
+const formatVersion = 6
 // Base path to access forecast data
 const dataPath = `data/${formatVersion}`
 export class ForecastMetadata {
@@ -117,7 +117,7 @@ export class ForecastMetadata {
   }
 
   urlOfVectorTilesAtHourOffset(zone: string, variablePath: string, hourOffset: number): string {
-    return `${dataPath}/${this.modelPath}/${this.initS}/${zone}/${variablePath}/${hourOffset}/{z}-{x}-{y}.json`
+    return `${dataPath}/${this.modelPath}/${this.initS}/${zone}/${variablePath}/${hourOffset}/{z}-{x}-{y}.mvt`
   }
 
   defaultHourOffset(): number {

--- a/frontend/src/map/Map.ts
+++ b/frontend/src/map/Map.ts
@@ -6,7 +6,7 @@ import { ScaleLine } from "ol/control";
 import { defaults as defaultInteractions } from "ol/interaction";
 import { Coordinate } from "ol/coordinate";
 import { Point } from 'ol/geom';
-import { GeoJSON } from "ol/format";
+import { MVT } from "ol/format";
 import { Style, Icon, Text, Fill } from 'ol/style';
 import { Accessor, createSignal } from 'solid-js';
 import windImg0 from '../images/wind-0.png';
@@ -186,7 +186,7 @@ export const initializeMap = (element: HTMLElement): MapHooks => {
         extent: extent,
         maxZoom: maxZoom,
         tileSize: tileSize,
-        format: new GeoJSON(),
+        format: new MVT(),
         transition: 1000
       }));
     },


### PR DESCRIPTION
For soarGFS, this decreases the size of the frontend assets from 20 GB to 11 GB.

For soarWRF, this decreases the size of the assets from 3.8 GB to 2.4 GB.

Note that the size of the data downloaded by the clients does not decrease, though, because JSON used to be transferred in gzip (although it is possible to enable gzip on .mvt assets too and save some kB).

You can see the result on https://soarwrf3.soaringmeteo.org/v2