### PR TITLE
Collect stats about the numerical weather prediction model used by our visitors

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,6 @@
         <meta name="description" content="Free weather information and forecast (WRF and GFS) for soaring (paragliding, hang-gliding, sailplane) pilots.">
         <link rel="icon" href="/src/favicoSoaringMeteo.png">
         <meta name="theme-color" content="#ffffff">
-        <script async data-domain="soaringmeteo.org" src="https://plausible.soaringmeteo.org/js/script.js"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-3.0-only",
   "dependencies": {
     "ol": "8.1.0",
+    "plausible-tracker": "0.3.8",
     "proj4": "2.9.2",
     "solid-js": "1.8.12"
   },

--- a/frontend/src/Plausible.tsx
+++ b/frontend/src/Plausible.tsx
@@ -1,0 +1,28 @@
+import { type Model } from "./State";
+
+/** Wrapper around the plausible-tracker package that loads it in the background */
+export class Plausible {
+
+  private plausible;
+
+  constructor() {
+    // Load the plausible-tracker module in the background to not block the users
+    this.plausible =
+      import('plausible-tracker').then(module =>
+        module.default({
+          domain: 'soaringmeteo.org',
+          apiHost: 'https://plausible.soaringmeteo.org',
+          // trackLocalhost: true // For development only
+        })
+      );
+  }
+
+  /** Register a “page view” event and attach the provided Model to it */
+  trackPageView(model: Model): void {
+    this.plausible.then(plausible => {
+      plausible.trackPageview({}, { props: { model } })
+    });
+  }
+
+}
+

--- a/frontend/src/map/Map.ts
+++ b/frontend/src/map/Map.ts
@@ -82,7 +82,7 @@ const saveLocationAndZoom = (location: [number, number], zoom: number) => {
   window.localStorage.setItem(locationAndZoomKey, JSON.stringify([[lat, lng], zoom]));
 };
 
-type MapHooks = {
+export type MapHooks = {
   locationClicks: Accessor<MapBrowserEvent<any> | undefined>
   setPrimaryLayerSource: (url: string, projection: string, extent: Extent) => void
   hidePrimaryLayer: () => void

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4943,6 +4943,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plausible-tracker@npm:0.3.8":
+  version: 0.3.8
+  resolution: "plausible-tracker@npm:0.3.8"
+  checksum: 066dd51586922fabbd70e4cfdeff77356669bf57852cd3cbc00d813938ed6637669ee615a1d7b865090550de61fc58bffb6e7c3e6d99f361ec7312d316033194
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.27":
   version: 8.4.33
   resolution: "postcss@npm:8.4.33"
@@ -5521,6 +5528,7 @@ __metadata:
     "@inlang/paraglide-js-adapter-vite": 1.2.14
     "@types/proj4": 2.5.4
     ol: 8.1.0
+    plausible-tracker: 0.3.8
     proj4: 2.9.2
     serve-static: 1.15.0
     solid-js: 1.8.12
@@ -5904,11 +5912,11 @@ __metadata:
 
 "typescript@patch:typescript@5.3.3#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=14eedb"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
+  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since the app uses the same URL `/v2` we can not monitor in the stats whether our users use the new interface to see the WRF results or the GFS results.

To address this issue, we replace the standard analytics script with a custom one that attaches a custom property to every “page view” event to indicate the underlying model (GFS or WRF).

As a consequence, we can now segment visits according to that property:

![image](https://github.com/soaringmeteo/soaringmeteo/assets/332812/f8b0a943-e725-443a-a94b-16a4780bf653)

Alternatively, we could rewrite the URL to use distinct URLs such as `/v2/gfs` and `/v2/wrf` but I believe custom properties attached to the page view events are a cleaner way to track that information.