### PR TITLE
Support hiding the map key

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -31,6 +31,8 @@
 	"settingsTimeUserTimezoneLegend": "Die Uhrzeit in meiner aktuellen Zeitzone statt in UTC anzeigen",
 	"settingsTimeUTC": "Uhrzeit in UTC anzeigen",
 	"settingsTimeUTCLegend": "UTC Zeit anzeigen, anstatt meine aktuelle Zeitzone zu verwenden",
+	"settingsMapKey": "Legende",
+	"settingsShowMapKey": "Legende auf der Karte anzeigen",
 	"locationSummary": "Zusammenfassung",
 	"locationSummaryLegend": "Zusammenfassung der Prognose für diesen Standort",
 	"locationMeteogram": "Meteogramm",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -31,6 +31,8 @@
   "settingsTimeUserTimezoneLegend": "Show time using my current timezone instead of UTC",
   "settingsTimeUTC": "Show time according to UTC",
   "settingsTimeUTCLegend": "Show UTC time instead of using my current timezone",
+  "settingsMapKey": "Map Key",
+  "settingsShowMapKey": "Show the map overlay key",
   "locationSummary": "Summary",
   "locationSummaryLegend": "Summary of the forecast for this location",
   "locationMeteogram": "Meteogram",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -31,6 +31,8 @@
   "settingsTimeUserTimezoneLegend": "Mostrar la hora usando mi zona horaria actual en lugar de UTC",
   "settingsTimeUTC": "Mostrar hora según UTC",
   "settingsTimeUTCLegend": "Mostrar la hora UTC en lugar de usar mi zona horaria actual",
+  "settingsMapKey": "Leyenda",
+  "settingsShowMapKey": "Mostrar leyenda del mapa",
   "locationSummary": "Resumen",
   "locationSummaryLegend": "Resumen del pronóstico para esta ubicación",
   "locationMeteogram": "Meteograma",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -31,6 +31,8 @@
   "settingsTimeUserTimezoneLegend": "Affiche les heures selon votre fuseau horaire plutôt qu’en UTC",
   "settingsTimeUTC": "Afficher les heures en UTC",
   "settingsTimeUTCLegend": "Affiche les heures en UTC plutôt que selon votre fuseau horaire",
+  "settingsMapKey": "Légende",
+  "settingsShowMapKey": "Afficher la légende sur la carte",
   "locationSummary": "Résumé",
   "locationSummaryLegend": "Résumé des prévisions pour ce lieu",
   "locationMeteogram": "Météogramme",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -30,6 +30,8 @@
 	"settingsTimeUserTimezoneLegend": "Mostra l'ora nel tuo fuso orario anziché in UTC",
 	"settingsTimeUTC": "Mostra l'ora in UTC",
 	"settingsTimeUTCLegend": "Mostra l'ora in UTC anziché nel tuo fuso orario",
+	"settingsMapKey": "Legenda",
+	"settingsShowMapKey": "Mostra la legenda della mappa",
 	"locationSummary": "Riepilogo",
 	"locationSummaryLegend": "Riepilogo delle previsioni per questo luogo",
 	"locationMeteogram": "Meteogramma",

--- a/frontend/messages/pl.json
+++ b/frontend/messages/pl.json
@@ -31,6 +31,8 @@
 	"settingsTimeUserTimezoneLegend": "Pokaż czas, używając mojej strefy czasowej zamiast UTC",
 	"settingsTimeUTC": "Pokaż czas według UTC",
 	"settingsTimeUTCLegend": "Pokaż czas UTC zamiast mojej strefy czasowej",
+	"settingsMapKey": "Legenda",
+	"settingsShowMapKey": "Pokaż legendę mapy",
 	"locationSummary": "Streszczenie",
 	"locationSummaryLegend": "Podsumowanie prognozy dla tej lokalizacji",
 	"locationMeteogram": "Meteogram",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -31,6 +31,8 @@
 	"settingsTimeUserTimezoneLegend": "Mostrar hora usando meu fuso horário atual em vez de UTC",
 	"settingsTimeUTC": "Mostrar hora de acordo com UTC",
 	"settingsTimeUTCLegend": "Mostrar a hora UTC em vez de usar meu fuso horário atual",
+	"settingsMapKey": "Legenda",
+	"settingsShowMapKey": "Mostrar legenda do mapa",
 	"locationSummary": "Resumo",
 	"locationSummaryLegend": "Resumo da previsão para este local",
 	"locationMeteogram": "Meteograma",

--- a/frontend/messages/sk.json
+++ b/frontend/messages/sk.json
@@ -31,6 +31,8 @@
     "settingsTimeUserTimezoneLegend": "Zobraziť čas pomocou môjho aktuálneho časového pásma namiesto UTC",
     "settingsTimeUTC": "Zobraziť čas podľa UTC",
     "settingsTimeUTCLegend": "Zobraziť čas UTC namiesto použitia môjho aktuálneho časového pásma",
+    "settingsMapKey": "Legenda",
+    "settingsShowMapKey": "Zobraziť legendu mapy",
     "locationSummary": "Súhrn",
     "locationSummaryLegend": "Súhrn predpovede pre toto miesto",
     "locationMeteogram": "Meteogram",

--- a/frontend/src/LayerKeys.tsx
+++ b/frontend/src/LayerKeys.tsx
@@ -6,7 +6,9 @@ export const LayerKeys = (props: {
 }): JSX.Element => {
   const primaryLayerComponents = () => props.domain.primaryLayerReactiveComponents();
 
-  return <Show when={ props.domain.state.primaryLayerEnabled }>
+  return <Show when={
+    props.domain.state.primaryLayerEnabled && props.domain.state.mapKeyShown
+  }>
     <div style={{
       position: 'absolute',
       bottom: '3rem',

--- a/frontend/src/Settings.tsx
+++ b/frontend/src/Settings.tsx
@@ -64,5 +64,14 @@ export const Settings = (props: {
         onChange={ () => props.domain.showUtcTime(true) }
       />
     </fieldset>
+    <fieldset style={{ 'margin-top': '.1em' }}>
+      <legend>{ m().settingsMapKey() }</legend>
+      <Checkbox
+        label={ m().settingsShowMapKey() }
+        checked={ props.domain.state.mapKeyShown }
+        onChange={ value => props.domain.showMapKey(value) }
+        labelPosition='right'
+      />
+    </fieldset>
   </Overlay>
 };

--- a/frontend/src/State.tsx
+++ b/frontend/src/State.tsx
@@ -31,6 +31,8 @@ export type State = {
   windNumericValuesShown: boolean
   // Whether to show UTC time instead of using the user timezone
   utcTimeShown: boolean
+  // Whether to show the map key
+  mapKeyShown: boolean
 }
 
 // Keys used to store the current display settings in the local storage
@@ -42,6 +44,7 @@ const primaryLayerEnabledKey = 'primary-layer-enabled';
 const windLayerEnabledKey       = 'wind-layer-enabled';
 const windNumericValuesShownKey = 'wind-numeric-values-shown';
 const utcTimeShownKey           = 'utc-time-shown';
+const mapKeyShownKey = 'map-key-shown';
 
 const loadStoredState = <A,>(key: string, parse: (raw: string) => A, defaultValue: A): A => {
   const maybeItem = window.localStorage.getItem(key);
@@ -150,6 +153,13 @@ const saveUtcTimeShown = (value: boolean): void => {
   window.localStorage.setItem(utcTimeShownKey, JSON.stringify(value));
 };
 
+const loadMapKeyShown = (): boolean =>
+  loadStoredState(mapKeyShownKey, raw => JSON.parse(raw), true);
+
+const saveMapKeyShown = (value: boolean): void => {
+  window.localStorage.setItem(mapKeyShownKey, JSON.stringify(value))
+}
+
 /**
  * Manages the interactions with the state of the system.
  * 
@@ -194,6 +204,7 @@ export class Domain {
     const windLayerEnabled = loadWindLayerEnabled();
     const windNumericValuesShown = loadWindNumericValuesShown();
     const utcTimeShown = loadUtcTimeShown();
+    const mapKeyShown = loadMapKeyShown();
   
     // FIXME handle map location and zoom here? (currently handled in /map/Map.ts)
     const [get, set] = createStore<State>({
@@ -207,7 +218,8 @@ export class Domain {
       hourOffset: forecastMetadata.defaultHourOffset(),
       detailedView: undefined,
       windNumericValuesShown,
-      utcTimeShown
+      utcTimeShown,
+      mapKeyShown
     }, { name: 'state' }); // See https://github.com/solidjs/solid/discussions/1414
 
     this.state = get;
@@ -359,6 +371,12 @@ export class Domain {
   showUtcTime(utcTimeShown: boolean): void {
     saveUtcTimeShown(utcTimeShown);
     this.setState({ utcTimeShown });
+  }
+
+  /** Whether to show the map key */
+  showMapKey(mapKeyShown: boolean): void {
+    saveMapKeyShown(mapKeyShown);
+    this.setState({ mapKeyShown })
   }
 
   /** The timezone to use according to the user’s preferences */

--- a/frontend/src/styles/Forms.tsx
+++ b/frontend/src/styles/Forms.tsx
@@ -26,7 +26,7 @@ export const Radio = (props: {
 export const Checkbox = (props: {
   label: string
   labelPosition?: 'left' | 'right'
-  title: string
+  title?: string
   checked: boolean
   onChange: (checked: boolean) => void
 }): JSX.Element =>
@@ -72,7 +72,7 @@ export const Select = <A,>(props: {
 
 export const Labelled = (props: {
   label: string
-  title: string
+  title?: string
   children: JSX.Element
   labelPosition?: 'left' | 'right'
 }): JSX.Element =>


### PR DESCRIPTION
Add a new setting allowing the users to hide the map key. This feature was requested on the “Soaringemeteo v2 feedback” channel.